### PR TITLE
Use the FilterExpression as a Dimmension filter in GA4

### DIFF
--- a/pkg/gav4/client.go
+++ b/pkg/gav4/client.go
@@ -91,6 +91,7 @@ func (client *GoogleClient) getReport(query model.QueryModel) (*analyticsdata.Ru
 			},
 		},
 		KeepEmptyRows: true,
+		DimensionFilter: query.FiltersExpression
 	}
 
 	log.DefaultLogger.Debug("Doing GET request from analytics reporting", "req", req)


### PR DESCRIPTION
Since the FilterExpression is not used in GA4 requests, leverage it as a Dimension Filter (https://developers.google.com/analytics/devguides/reporting/data/v1/basics#dimension_filters) such that the data can be filtered. This would require the string to be a Filter Expression object https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression

Example (taken from here - https://ga-dev-tools.google/ga4/query-explorer/):
"filter":{ "fieldName":"searchTerm" "stringFilter":{ "matchType":"FULL_REGEXP" "value":"[a-zA-Z]{4,}" } }
