### PR TITLE
release 0.3.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
         run: docker-compose down
 
       - name: Archive E2E output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.check-for-e2e.outputs.has-e2e == 'true' && steps.run-e2e-tests.outcome != 'success'
         with:
           name: cypress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1
+- Support or,and,not filter[#128](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/128)
+- Support grafana version < 13[#136](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/136)
+- Fix github actions [#136](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/136)
+- Update README.md[#127](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/127)
+
 ## 0.3.0
 - Fix timezone no zoneinfo.zip([#102](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/102))
 - Supprot variable at Dimensions Filter([#103](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/103))

--- a/provisioning/dashboards/v0.3.0.json
+++ b/provisioning/dashboards/v0.3.0.json
@@ -1,0 +1,157 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "blackcowmoo-googleanalytics-datasource",
+        "uid": "lcc3108_test"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "accountId": "accounts/145710468",
+          "cacheDurationSeconds": 300,
+          "datasource": {
+            "type": "blackcowmoo-googleanalytics-datasource",
+            "uid": "eemfkybhl4ydca"
+          },
+          "dimensionFilter": {},
+          "displayName": {},
+          "metrics": [
+            "activeUsers"
+          ],
+          "mode": "time series",
+          "refId": "A",
+          "selectedMetrics": [
+            {
+              "description": "The number of distinct users who visited your site or app.",
+              "label": "Active users",
+              "value": "activeUsers"
+            }
+          ],
+          "selectedTimeDimensions": {
+            "description": "The date of the event, formatted as YYYYMMDD.",
+            "label": "Date",
+            "value": "date"
+          },
+          "serviceLevel": "GOOGLE_ANALYTICS_STANDARD",
+          "timeDimension": "date",
+          "timezone": "Asia/Seoul",
+          "version": "v4",
+          "webPropertyId": "properties/323466308"
+        }
+      ],
+      "title": "Panel Title",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "v0.3.0",
+  "uid": "eemfl56a7hdz4a",
+  "version": 1,
+  "weekStart": ""
+}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -52,7 +52,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=9 <12.0.0",
+    "grafanaDependency": ">=9 <13.0.0",
     "plugins": []
   }
 }

--- a/tests/query/queryEdiyor.spec.ts
+++ b/tests/query/queryEdiyor.spec.ts
@@ -1,20 +1,24 @@
 import { expect, test } from '@grafana/plugin-e2e';
+import * as fs from 'fs';
+import * as path from 'path';
 
+// 대시보드 버전 목록 가져오기
+const getDashboardVersions = () => {
+  const dashboardsDir = path.join(__dirname, '../../provisioning/dashboards');
+  const files = fs.readdirSync(dashboardsDir);
+  return files
+    .filter(file => file.match(/^v\d+\.\d+\.\d+\.json$/))
+    .map(file => file.replace('.json', ''));
+};
 
-test('0_2_2 migration test', async ({ readProvisionedDataSource, readProvisionedDashboard, gotoDashboardPage }) => {
-  // default settings
-  const dashboard = await readProvisionedDashboard({fileName: 'v0.2.2.json'})
-  const dashboardPage = await gotoDashboardPage({uid: dashboard.uid});
-  await dashboardPage.refreshDashboard()
-  await expect(dashboardPage.waitForQueryDataResponse()).toBeOK()
-});
-
-test('0_2_3 migration test', async ({ readProvisionedDataSource, readProvisionedDashboard, gotoDashboardPage }) => {
-  // default settings
-  const dashboard = await readProvisionedDashboard({fileName: 'v0.2.3.json'})
-  const dashboardPage = await gotoDashboardPage({uid: dashboard.uid});
-  await dashboardPage.refreshDashboard()
-  await expect(dashboardPage.waitForQueryDataResponse()).toBeOK()
+// 각 버전별 마이그레이션 테스트
+getDashboardVersions().forEach(version => {
+  test(`${version} migration test`, async ({ readProvisionedDataSource, readProvisionedDashboard, gotoDashboardPage }) => {
+    const dashboard = await readProvisionedDashboard({fileName: `${version}.json`});
+    const dashboardPage = await gotoDashboardPage({uid: dashboard.uid});
+    await dashboardPage.refreshDashboard();
+    await expect(dashboardPage.waitForQueryDataResponse()).toBeOK();
+  });
 });
 
 test('time series', async ({ readProvisionedDataSource, explorePage, page }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Grafana 플러그인의 호환 버전 범위를 Grafana 13.0.0 미만까지 확장했습니다. 이제 Grafana 9 이상 13.0.0 미만 버전에서 플러그인을 사용할 수 있습니다.
  - E2E 테스트 결과 아티팩트 업로드 작업이 최신 버전의 GitHub Actions 액션을 사용하도록 업데이트되었습니다.
- **New Features**
  - Google Analytics 활성 사용자 데이터를 시각화하는 새로운 Grafana 대시보드가 추가되었습니다.
  - 논리 필터(AND, OR, NOT) 지원이 추가되었습니다.
- **Bug Fixes**
  - GitHub Actions 워크플로우 관련 문제들이 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->