### PR TITLE
Investigate and resolve grafana google analytics issue

### DIFF
--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -14,8 +14,16 @@ export type Props = DataSourcePluginOptionsEditorProps<GADataSourceOptions, GASe
 export class ConfigEditor extends PureComponent<Props> {
   constructor(props: Readonly<Props>) {
     super(props);
-    if (!this.props.options.jsonData.version) {
-      this.props.options.jsonData.version = 'v4';
+    const { options, onOptionsChange } = props;
+    // Avoid mutating props directly – instead, use onOptionsChange to set the default value immutably
+    if (!options.jsonData.version) {
+      onOptionsChange({
+        ...options,
+        jsonData: {
+          ...options.jsonData,
+          version: 'v4',
+        },
+      });
     }
   }
   onResetProfileId = () => {


### PR DESCRIPTION
Refactor ConfigEditor to set default version immutably, preventing direct prop mutation.

Previously, the `ConfigEditor` directly assigned a value to `this.props.options.jsonData.version`. This approach violates React's immutability principles and could lead to unexpected behavior or compatibility issues with future Grafana React upgrades, as reported in #144.

---
<a href="https://cursor.com/background-agent?bcId=bc-229a6d0b-4599-42eb-840a-688299971f36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-229a6d0b-4599-42eb-840a-688299971f36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터링
  - ConfigEditor에서 props 직접 변경을 제거하고 불변 업데이트 방식으로 전환했습니다.
  - 기본 버전 값이 없을 때 ‘v4’를 자동 설정하되, 상태 갱신은 콜백을 통해 수행합니다.
  - 사용자 관점의 기능은 동일하지만, 상태 관리의 예측 가능성과 안정성이 향상되었습니다.
  - 잠재적 부작용을 줄여 오류 가능성을 낮추고, 기존 설정과의 호환성을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->