### PR TITLE
feat: Add dashboard variable support for webPropertyId

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -25,8 +25,13 @@ export class DataSource extends DataSourceWithBackend<GAQuery, GADataSourceOptio
       }
       return expression;
     });
+
+    // Apply template variable interpolation to webPropertyId
+    const webPropertyId = templateSrv.replace(query.webPropertyId, scopedVars);
+
     return {
       ...query,
+      webPropertyId,
       dimensionFilter,
     };
   }


### PR DESCRIPTION
## What
Add dashboard variable support for webPropertyId field, answering [issue 109](https://github.com/blackcowmoo/grafana-google-analytics-datasource/issues/109)

## Why
Dimension filters already support template variables, but webPropertyId 
was missing this feature. This prevents users from dynamically switching 
between GA properties using dashboard variables.

## How
Added `templateSrv.replace()` call for webPropertyId in 
`applyTemplateVariables()`, following the existing pattern for 
dimension filters.

## Testing
- [x] TypeScript type check passes
- [x] Lint passes (on modified file)
- [x] Frontend builds successfully
- [x] Backend builds successfully
- [x] Manually tested in Grafana

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 웹 속성 ID에 대한 템플릿 변수 보간이 올바르게 작동하도록 수정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->