### PR TITLE
fix: avoid mutating props in ConfigEditor (#144)

### DIFF
--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -14,8 +14,16 @@ export type Props = DataSourcePluginOptionsEditorProps<GADataSourceOptions, GASe
 export class ConfigEditor extends PureComponent<Props> {
   constructor(props: Readonly<Props>) {
     super(props);
-    if (!this.props.options.jsonData.version) {
-      this.props.options.jsonData.version = 'v4';
+    const { options, onOptionsChange } = props;
+    // Avoid mutating props directly – instead, use onOptionsChange to set the default value immutably
+    if (!options.jsonData.version) {
+      onOptionsChange({
+        ...options,
+        jsonData: {
+          ...options.jsonData,
+          version: 'v4',
+        },
+      });
     }
   }
   onResetProfileId = () => {


### PR DESCRIPTION
## Summary
- `ConfigEditor` constructor previously wrote to `this.props.options.jsonData.version` directly, which violates React's prop-purity rules and may break under future Grafana/React upgrades.
- Replace the direct assignment with `onOptionsChange` so the default `v4` version is set immutably via the parent update channel.

Fixes #144

## Test plan
- [ ] `yarn typecheck` passes
- [ ] Data source config page loads without the version defaulting to `undefined`
- [ ] Newly created datasource has `version: 'v4'` applied after first render

## Notes
Supersedes #145 (draft) and #146 — same intent, consolidated into a single branch off current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * ConfigEditor 컴포넌트의 내부 상태 관리 로직을 개선하여 안정성을 향상시켰습니다.

**참고**: 이번 업데이트는 사용자에게 보이는 기능 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->