### PR TITLE
fix: respect sub-day Grafana time range in time-series output (#108)

### DIFF
--- a/pkg/gav3/analytics.go
+++ b/pkg/gav3/analytics.go
@@ -52,7 +52,7 @@ func (ga *GoogleAnalytics) Query(ctx context.Context, config *setting.Datasource
 		return nil, err
 	}
 
-	return transformReportsResponseToDataFrames(report, queryModel.RefID, queryModel.Timezone)
+	return transformReportsResponseToDataFrames(report, queryModel.RefID, queryModel.Timezone, queryModel.From, queryModel.To)
 }
 
 func (ga *GoogleAnalytics) GetTimezone(ctx context.Context, config *setting.DatasourceSecretSettings, accountId string, webPropertyId string, profileId string) (string, error) {

--- a/pkg/gav3/grafana.go
+++ b/pkg/gav3/grafana.go
@@ -77,7 +77,7 @@ func transformReportToDataFrameByDimensions(columns []*model.ColumnDefinition, r
 // <--------- primary secondary --------->
 var timeDimensions []string = []string{"ga:dateHourMinute", "ga:dateHour", "ga:date"}
 
-func transformReportToDataFrames(report *reporting.Report, refId string, timezone string) ([]*data.Frame, error) {
+func transformReportToDataFrames(report *reporting.Report, refId string, timezone string, from, to time.Time) ([]*data.Frame, error) {
 	timeDimension := reporting.MetricHeaderEntry{
 		Name: report.ColumnHeader.Dimensions[0],
 		Type: "TIME",
@@ -103,6 +103,16 @@ func transformReportToDataFrames(report *reporting.Report, refId string, timezon
 			// aggregate "(other)" bucket when the response exceeds the
 			// cardinality limit). Skip from time-series output.
 			continue
+		}
+		// Google Analytics UA reports only accept day-resolution date ranges,
+		// so sub-day Grafana ranges (e.g. "Last 6 hours") fetch entire days.
+		// Drop rows whose bucket does not intersect [from, to] (issue #108).
+		// Skipped when the caller did not supply a range (zero time = unset).
+		if !from.IsZero() && !to.IsZero() {
+			bucketEnd := timeAddFunction(*parsedTime)
+			if !parsedTime.Before(to) || !bucketEnd.After(from) {
+				continue
+			}
 		}
 		dimension := strings.Join(parsedRow.Dimensions, "|")
 		if _, ok := dimensions[dimension]; !ok {
@@ -166,10 +176,10 @@ func transformReportToDataFrames(report *reporting.Report, refId string, timezon
 	return frames, nil
 }
 
-func transformReportsResponseToDataFrames(reportsResponse *reporting.GetReportsResponse, refId string, timezone string) (*data.Frames, error) {
+func transformReportsResponseToDataFrames(reportsResponse *reporting.GetReportsResponse, refId string, timezone string, from, to time.Time) (*data.Frames, error) {
 	var frames = make(data.Frames, 0)
 	for _, report := range reportsResponse.Reports {
-		frame, err := transformReportToDataFrames(report, refId, timezone)
+		frame, err := transformReportToDataFrames(report, refId, timezone, from, to)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/gav4/analytics.go
+++ b/pkg/gav4/analytics.go
@@ -54,7 +54,7 @@ func (ga *GoogleAnalytics) Query(ctx context.Context, config *setting.Datasource
 		return nil, err
 	}
 
-	return transformReportsResponseToDataFrames(report, queryModel.RefID, queryModel.Timezone, queryModel.Mode)
+	return transformReportsResponseToDataFrames(report, queryModel.RefID, queryModel.Timezone, queryModel.Mode, queryModel.From, queryModel.To)
 
 }
 

--- a/pkg/gav4/grafana.go
+++ b/pkg/gav4/grafana.go
@@ -113,7 +113,7 @@ func transformReportToDataFramesTableMode(report *analyticsdata.RunReportRespons
 	return frames, nil
 }
 
-func transformReportToDataFrames(report *analyticsdata.RunReportResponse, refId string, timezone string) ([]*data.Frame, error) {
+func transformReportToDataFrames(report *analyticsdata.RunReportResponse, refId string, timezone string, from, to time.Time) ([]*data.Frame, error) {
 
 	timeDimension := analyticsdata.MetricHeader{
 		Name: report.DimensionHeaders[0].Name,
@@ -140,6 +140,16 @@ func transformReportToDataFrames(report *analyticsdata.RunReportResponse, refId 
 			// aggregate "(other)" bucket when the response exceeds the
 			// cardinality limit). Skip from time-series output.
 			continue
+		}
+		// Google Analytics Data API only accepts day-resolution date ranges,
+		// so sub-day Grafana ranges (e.g. "Last 6 hours") fetch entire days.
+		// Drop rows whose bucket does not intersect [from, to] (issue #108).
+		// Skipped when the caller did not supply a range (zero time = unset).
+		if !from.IsZero() && !to.IsZero() {
+			bucketEnd := timeAddFunction(*parsedTime)
+			if !parsedTime.Before(to) || !bucketEnd.After(from) {
+				continue
+			}
 		}
 		var dimension string = ""
 		for _, v := range parsedRow.DimensionValues {
@@ -208,19 +218,16 @@ func transformReportToDataFrames(report *analyticsdata.RunReportResponse, refId 
 	return frames, nil
 }
 
-func transformReportsResponseToDataFrames(reportsResponse *analyticsdata.RunReportResponse, refId string, timezone string, mode model.QueryMode) (*data.Frames, error) {
+func transformReportsResponseToDataFrames(reportsResponse *analyticsdata.RunReportResponse, refId string, timezone string, mode model.QueryMode, from, to time.Time) (*data.Frames, error) {
 	var frames = make(data.Frames, 0)
-	// for _, report := range reportsResponse.Rows {
-	var transformReportToDataFramesFn func(*analyticsdata.RunReportResponse, string, string) ([]*data.Frame, error)
+	var frame []*data.Frame
+	var err error
 	switch mode {
-	case model.TIME_SERIES:
-		transformReportToDataFramesFn = transformReportToDataFrames
 	case model.TABLE, model.REALTIME:
-		transformReportToDataFramesFn = transformReportToDataFramesTableMode
+		frame, err = transformReportToDataFramesTableMode(reportsResponse, refId, timezone)
 	default:
-		transformReportToDataFramesFn = transformReportToDataFrames
+		frame, err = transformReportToDataFrames(reportsResponse, refId, timezone, from, to)
 	}
-	frame, err := transformReportToDataFramesFn(reportsResponse, refId, timezone)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gav4/grafana_test.go
+++ b/pkg/gav4/grafana_test.go
@@ -53,3 +53,94 @@ func TestParseRow_UnparseableTimeDimensionIsSkipped(t *testing.T) {
 		t.Fatalf("expected nil row and time for unparseable value, got row=%v time=%v", parsedRow, parsedTime)
 	}
 }
+
+func TestTransformReportToDataFrames_FiltersSubDayRange(t *testing.T) {
+	// Regression: Grafana time range smaller than a day (e.g. "Last 6 hours")
+	// must drop GA rows whose bucket falls outside the range (issue #108).
+	header := &analyticsdata.DimensionHeader{Name: "dateHour"}
+	metricHeader := &analyticsdata.MetricHeader{Name: "activeUsers", Type: "TYPE_INTEGER"}
+	mkRow := func(t, v string) *analyticsdata.Row {
+		return &analyticsdata.Row{
+			DimensionValues: []*analyticsdata.DimensionValue{{Value: t}},
+			MetricValues:    []*analyticsdata.MetricValue{{Value: v}},
+		}
+	}
+	report := &analyticsdata.RunReportResponse{
+		DimensionHeaders: []*analyticsdata.DimensionHeader{header},
+		MetricHeaders:    []*analyticsdata.MetricHeader{metricHeader},
+		Rows: []*analyticsdata.Row{
+			mkRow("2024091202", "1"), // before window (02:00)
+			mkRow("2024091204", "2"), // inside window (04:00)
+			mkRow("2024091205", "3"), // inside window (05:00)
+			mkRow("2024091210", "4"), // after window (10:00)
+		},
+	}
+	from := time.Date(2024, 9, 12, 3, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 9, 12, 9, 0, 0, 0, time.UTC)
+
+	frames, err := transformReportToDataFrames(report, "A", "UTC", from, to)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(frames) == 0 {
+		t.Fatalf("expected at least one frame, got 0")
+	}
+	// The time-series transform also synthesizes adjacent zero-filled buckets.
+	// We only assert that the rows outside the window are dropped.
+	frame := frames[0]
+	times, ok := frame.Fields[0].At(0).(*time.Time)
+	_ = times
+	_ = ok
+	// Count actual data rows (non-zero activeUsers). With filtering, only the
+	// two in-range rows (values 2 and 3) should survive.
+	nonZero := 0
+	for i := 0; i < frame.Fields[1].Len(); i++ {
+		v := frame.Fields[1].At(i)
+		if f, ok := v.(*float64); ok && f != nil && *f > 0 {
+			nonZero++
+		}
+	}
+	if nonZero != 2 {
+		t.Errorf("expected 2 in-range data rows, got %d", nonZero)
+	}
+}
+
+func TestTransformReportToDataFrames_NoRangeKeepsAllRows(t *testing.T) {
+	// When caller passes zero-value from/to, filtering is bypassed and all
+	// rows survive (back-compat path).
+	header := &analyticsdata.DimensionHeader{Name: "dateHour"}
+	metricHeader := &analyticsdata.MetricHeader{Name: "activeUsers", Type: "TYPE_INTEGER"}
+	mkRow := func(t, v string) *analyticsdata.Row {
+		return &analyticsdata.Row{
+			DimensionValues: []*analyticsdata.DimensionValue{{Value: t}},
+			MetricValues:    []*analyticsdata.MetricValue{{Value: v}},
+		}
+	}
+	report := &analyticsdata.RunReportResponse{
+		DimensionHeaders: []*analyticsdata.DimensionHeader{header},
+		MetricHeaders:    []*analyticsdata.MetricHeader{metricHeader},
+		Rows: []*analyticsdata.Row{
+			mkRow("2024091202", "1"),
+			mkRow("2024091210", "4"),
+		},
+	}
+
+	frames, err := transformReportToDataFrames(report, "A", "UTC", time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(frames) == 0 {
+		t.Fatalf("expected at least one frame")
+	}
+	nonZero := 0
+	frame := frames[0]
+	for i := 0; i < frame.Fields[1].Len(); i++ {
+		v := frame.Fields[1].At(i)
+		if f, ok := v.(*float64); ok && f != nil && *f > 0 {
+			nonZero++
+		}
+	}
+	if nonZero != 2 {
+		t.Errorf("expected both rows kept without range filter, got %d non-zero", nonZero)
+	}
+}


### PR DESCRIPTION
## Summary
- GA Data API / UA reporting API only accept day-resolution date ranges. Grafana's sub-day ranges (e.g. \"Last 6 hours\") therefore pulled entire days and rendered all of them, reporting metrics for the full day instead of the requested window (#108).
- Thread \`QueryModel.From\` / \`QueryModel.To\` into the time-series transform for both \`gav3\` and \`gav4\`.
- Drop rows whose bucket \`[parsedTime, parsedTime + bucketSize)\` does not intersect \`[from, to]\`. Zero-valued range disables the filter for back-compat.
- Adds two regression tests plus keeps existing ones green (4/4).

Fixes #108

## Stacking
Based on \`fix/121-other-row-parse\` (#155) because both branches share the \`parseRow\` return shape. Retarget to \`master\` once #155 merges, or merge in order.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./pkg/gav4/...\` passes (4/4)
- [ ] Manual: \"Last 6 hours\" panel with \`dateHour\` time dimension renders only the 6-hour window
- [ ] Manual: full-day range behaviour unchanged

## Notes
Users should still pick a time dimension at the right resolution — \`dateHour\` for ≤ 24h ranges, \`date\` for longer spans. With \`date\` dimension the filter keeps buckets whose 24h span touches the window, which matches the maintainer's note in #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Google Analytics 쿼리 결과에서 요청한 날짜 범위 내의 데이터만 정확하게 필터링되도록 개선되었습니다.
  * 파싱 불가능한 데이터 행을 건너뛰어 더 안정적인 결과를 제공합니다.

* **테스트**
  * 날짜 범위 필터링 및 데이터 파싱 로직에 대한 포괄적인 테스트 커버리지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->