### PR TITLE
docs: expand setup instructions and troubleshooting (#100)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -5,3 +5,64 @@
 2. [service account check](https://console.cloud.google.com/apis/credentials)
   ![img](https://github.com/blackcowmoo/Grafana-Google-Analytics-DataSource/blob/master/img/serviceaccount.png?raw=true)
 3. [analytics account access check](https://analytics.google.com/analytics)
+
+## Query problems
+
+### `Web property ID` — what format?
+
+- **GA4:** `properties/XXXXXXXXX` (numeric property id prefixed with `properties/`). You can copy this from GA4 Admin → Property Settings.
+- **UA (deprecated):** numeric web property id, e.g. `UA-XXXXXXX-1`.
+
+### Why does my `Last 6 hours` panel show data for the whole day?
+
+Google Analytics reporting APIs only accept day-resolution date ranges, so the plugin pulls full days from GA and filters the response down to the Grafana time range. To make this work correctly, pick a time dimension with the right resolution:
+
+- `dateHour` (or `dateHourMinute` for GA4) for sub-day ranges.
+- `date` for multi-day ranges.
+
+The plugin drops buckets that fall outside the requested window; choosing a coarser dimension (e.g. `date` for a 6-hour range) may therefore produce empty results.
+
+### Why does my query fail with `Cohort metrics can only be used in requests with a CohortSpec`?
+
+Cohort metrics (any metric under the **Cohort** group) require a `cohortSpec` in the request payload, which the plugin does not yet build automatically. Until cohort support lands, select metrics from other groups.
+
+### Dashboard variables
+
+The plugin interpolates Grafana variables in:
+
+- **Web property ID** — allows one panel repeated across multiple GA4 properties. Use a multi-value variable and Grafana's *Repeat panel* feature.
+- **Dimension filter** — both `STRING` and `IN_LIST` filter values. For multi-select variables with `IN_LIST`, the plugin expands the variable into one filter value per selected item; just write the plain variable reference, e.g. `$campaigns`.
+- **`filtersExpression`** (UA) — plain string substitution.
+
+For string filters that need to match any of several values, use the `FULL_REGEXP` match type with Grafana's regex format specifier, e.g. `${myVar:regex}`.
+
+## Service account & permissions
+
+### Which APIs must be enabled on the GCP project?
+
+- **GA4:** `analyticsadmin.googleapis.com` and `analyticsdata.googleapis.com`.
+- **UA:** `analytics.googleapis.com` and `analyticsreporting.googleapis.com`.
+
+### What GA role does the service account need?
+
+Add the service account email to your Google Analytics property with the **Viewer** (GA4) or **Read & Analyze** (UA) role. No role at the GCP project level is required.
+
+### The data source test says "Not Exist Valid Profile"
+
+The service account was successfully authenticated but has no visibility into any GA4 property / UA view. Re-check:
+
+1. The service account email (ending in `iam.gserviceaccount.com`) is added as a user on the GA property.
+2. For GA4, the property is reachable via the Admin API (not just the Data API) — the admin API lists properties and is used by the account picker.
+
+## Dev & troubleshooting
+
+### Enable plugin debug logs
+
+Set `log.level=debug` in `grafana.ini` to see the plugin's request/response logs:
+
+```
+[log]
+level = debug
+```
+
+See the [Grafana logging reference](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#log) for more detail.

--- a/README.md
+++ b/README.md
@@ -7,35 +7,48 @@ Visualize data from Google Analytics UA(Deprecated) And GA4(beta)
 - AutoComplete AccountID & WebpropertyID & ProfileID
 - AutoComplete Metrics & Dimensions
 - Query using Metrics & Dimensions
+- Dimension filter with AND / OR / NOT groups (GA4)
+- Dashboard variable support for `webPropertyId` and dimension-filter values
 - Setting with json
 
 ![query](https://github.com/blackcowmoo/Grafana-Google-Analytics-DataSource/blob/master/src/img/query.png?raw=true)
 
 ## Preparations
-### Generate a JWT file
 
-1.  if you don't have gcp project, add new gcp project. [link](https://cloud.google.com/resource-manager/docs/creating-managing-projects#console)
-2.  Open the [Credentials](https://console.developers.google.com/apis/credentials) page in the Google API Console.
-3.  Click **Create Credentials** then click **Service account**.
-4.  On the Create service account page, enter the Service account details.
-5.  On the `Create service account` page, fill in the `Service account details` and then click `Create`
-6.  On the `Service account permissions` page, don't add a role to the service account. Just click `Continue`
-7.  In the next step, click `Create Key`. Choose key type `JSON` and click `Create`. A JSON key file will be created and downloaded to your computer
-8.  Note your `service account email` ex) *@*.iam.gserviceaccount.com
-9.  Open the [Google Analytics Admin API](https://console.cloud.google.com/apis/library/analyticsadmin.googleapis.com)  in API Library and enable access for your account
-10. Open the [Google Analytics Data API](https://console.cloud.google.com/apis/library/analyticsdata.googleapis.com)  in API Library and enable access for your GA Data
+Setup has three stages: create a Google Cloud service account, grant it access in Google Analytics, and upload the key file in Grafana. Do them in order.
 
-### Google Analytics Setting
+### 1. Create a Google Cloud service account
 
-1. Open the [Google Analytics](https://analytics.google.com/)
-2. Select Your Analytics Account And Open Admin Page
-3. Click **Account User Management** on the **Account Tab**
-4. Click plus Button then Add users
-5. Enter `service account email` at **Generate a JWT file** 8th step and Permissions add `Read & Analyze`
+1. If you don't already have a GCP project, [create one](https://cloud.google.com/resource-manager/docs/creating-managing-projects#console).
+2. Open the [Credentials](https://console.developers.google.com/apis/credentials) page in the Google API Console.
+3. Click **Create Credentials** → **Service account**.
+4. Fill in the service account details and click **Create**.
+5. On the **Service account permissions** page, leave the role empty (no project-level role is required) and click **Continue**.
+6. Open the newly-created service account and click **Keys** → **Add Key** → **Create new key** → **JSON**. A JSON key file will download.
+7. Note the service account email — it looks like `*@*.iam.gserviceaccount.com`. You'll need it in the next step.
 
-### Grafana
-Go To Add Data source then Drag the file to the dotted zone above. Then click `Save & Test`.   
-The file contents will be encrypted and saved in the Grafana database.
+### 2. Enable the required APIs
+
+Enable the following APIs for the GCP project that owns the service account:
+
+- **GA4 (recommended):** [Google Analytics Admin API](https://console.cloud.google.com/apis/library/analyticsadmin.googleapis.com) and [Google Analytics Data API](https://console.cloud.google.com/apis/library/analyticsdata.googleapis.com).
+- **UA (deprecated, read-only):** [Google Analytics API](https://console.cloud.google.com/apis/library/analytics.googleapis.com) and [Google Analytics Reporting API](https://console.cloud.google.com/marketplace/product/google/analyticsreporting.googleapis.com).
+
+Confirm they are enabled on the [API dashboard](https://console.cloud.google.com/apis/dashboard).
+
+### 3. Grant the service account access in Google Analytics
+
+1. Open [Google Analytics](https://analytics.google.com/) and select your account.
+2. Open **Admin**.
+3. **GA4:** open **Property access management** on the property you want to query. **UA:** open **Account User Management** on the account tab.
+4. Click **+** → **Add users** and enter the service account email from step 1.7.
+5. Grant the **Viewer** role (GA4) or **Read & Analyze** permission (UA).
+
+### 4. Add the data source in Grafana
+
+Go to **Add data source** in Grafana, pick this plugin, drag the JSON key file onto the upload area, and click **Save & Test**. The key is encrypted at rest in the Grafana database.
+
+Common setup problems are covered in the [FAQ](./FAQ.md).
 
 ## FAQ
 [FAQ](https://github.com/blackcowmoo/Grafana-Google-Analytics-DataSource/tree/master/FAQ.md)


### PR DESCRIPTION
## Summary
- Restructure README setup into 4 numbered stages (GCP → APIs → GA → Grafana) with GA4 vs UA called out at each step.
- Advertise dashboard variables and AND/OR/NOT dimension-filter groups on the feature list.
- Expand FAQ with the recurring questions we've seen in the issue tracker: web property ID format, sub-day range behaviour (links to the fix in #156), cohort limitation (#149), dashboard variable / multi-select usage (#154), common service-account access pitfalls, and how to turn on debug logs.

Fixes #100

## Test plan
- [ ] Render locally to confirm markdown
- [ ] Cross-check links against current Google Cloud / Analytics console UI

## Notes
Screenshots/visuals from the original ask are not included in this PR — happy to follow up with a wiki page if the maintainer wants image-based docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)