### PR TITLE
test(e2e): fix query-mode selector for Grafana 12+

### DIFF
--- a/tests/query/queryEdiyor.spec.ts
+++ b/tests/query/queryEdiyor.spec.ts
@@ -1,6 +1,25 @@
 import { expect, test } from '@grafana/plugin-e2e';
+import type { Locator } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
+
+// Grafana 10.4.5+ renders the RadioButtonGroup with a visible <label> and a
+// stacked opacity:0 <input>, so Playwright's `.check()` on the native input
+// times out (waits for visibility) and a plain `.click()` on the label is
+// blocked by the input's pointer-event interception. Use `force: true` to
+// click the visible label directly. Fall back to the old plain-text path for
+// pre-10.4.5 Grafana (no label-wrapped radios).
+const selectQueryMode = async (row: Locator, mode: string) => {
+  const label = row
+    .getByLabel('query-mode')
+    .locator('label')
+    .filter({ hasText: new RegExp(`^${mode}\\s*$`) });
+  if ((await label.count()) > 0) {
+    await label.click({ force: true });
+    return;
+  }
+  await row.getByText(mode, { exact: true }).check();
+};
 
 // 대시보드 버전 목록 가져오기
 const getDashboardVersions = () => {
@@ -28,12 +47,7 @@ test('time series', async ({ readProvisionedDataSource, explorePage, page }) => 
   await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
 
-  let queryMode =  explorePage.getQueryEditorRow('A').getByLabel('query-mode').getByLabel('Time Series')
-  // for grafana version < 10.4.5
-  if(await queryMode.count()==0){
-    queryMode =  explorePage.getQueryEditorRow('A').getByText('Time Series',{exact: true})
-  }
-  await queryMode.check()
+  await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Time Series');
 
   // account select
   await explorePage.getQueryEditorRow('A').getByRole('button', { name: 'Account Select' }).click();
@@ -68,12 +82,8 @@ test('table', async ({ readProvisionedDataSource, explorePage, page }) => {
 
   await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
-  let queryMode =  explorePage.getQueryEditorRow('A').getByLabel('query-mode').getByLabel('Table')
-  // for grafana version < 10.4.5
-  if(await queryMode.count()==0){
-    queryMode =  explorePage.getQueryEditorRow('A').getByText('Table',{exact: true})
-  }
-  await queryMode.check()  // account select
+  await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Table');
+  // account select
   await explorePage.getQueryEditorRow('A').getByRole('button', { name: 'Account Select' }).click();
   await page.getByText('Default Account for Firebase').click();
   await page.getByText('gitblog - GA4').click();
@@ -106,12 +116,8 @@ test('realtime', async ({ readProvisionedDataSource, explorePage, page }) => {
 
   await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
-  let queryMode =  explorePage.getQueryEditorRow('A').getByLabel('query-mode').getByLabel('Realtime')
-  // for grafana version < 10.4.5
-  if(await queryMode.count()==0){
-    queryMode =  explorePage.getQueryEditorRow('A').getByText('Realtime',{exact: true})
-  }
-  await queryMode.check()  // account select
+  await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Realtime');
+  // account select
   await explorePage.getQueryEditorRow('A').getByRole('button', { name: 'Account Select' }).click();
   await page.getByText('Default Account for Firebase').click();
   await page.getByText('gitblog - GA4').click();


### PR DESCRIPTION
## Summary
Every open PR currently fails e2e on Grafana 12.2.8 and 13.0.1 — including PRs that only change docs (#157) — because the radio button selector in the query-mode test was broken by a @grafana/ui DOM change bundled with Grafana 10.4.5+.

## Root cause
Grafana 10.4.5+ renders \`RadioButtonGroup\` with the native \`<input>\` at \`opacity:0\` stacked above a visible \`<label>\`. Playwright's \`.check()\` waits for the input to be visible and times out after 30s. A plain \`.click()\` on the label is then intercepted by the invisible-but-present input.

## Fix
- Extract \`selectQueryMode(row, mode)\` helper in \`tests/query/queryEdiyor.spec.ts\` that:
  - Finds the visible \`<label>\` inside the \`query-mode\` radio group (tolerating the trailing whitespace @grafana/ui emits in the label text).
  - Clicks it with \`force: true\` to bypass the opacity:0 input's pointer-event interception.
  - Falls back to the pre-10.4.5 plain-text \`.check()\` path when the label markup isn't present.
- Replace the three inline selectors (Time Series / Table / Realtime) with helper calls.

## Verified locally
| Grafana | Result |
|---|---|
| 11.3.9 | passed (no regression) |
| 12.2.8 | passed (newly fixed) |
| 13.0.1 | passed (newly fixed) |

Verified by spinning up each Grafana version via docker-compose and running a temporary spec that exercises the new \`selectQueryMode\` against all three mode labels; in every case the correct radio ended up \`:checked\`.

## Test plan
- [ ] \`yarn e2e\` green on Grafana 12.2.8 and 13.0.1 in CI
- [ ] \`yarn e2e\` still green on Grafana 9.0.8 / 9.3.16 / 10.3.12 / 11.3.9
- [ ] After merge, retrigger CI on #153 / #154 / #155 / #156 / #157 / #158 — all Grafana 12/13 failures should disappear

## Impact
Unblocks CI on every open PR. Should be merged first so the other PRs rebase onto a green master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 쿼리 에디터 테스트의 쿼리 모드 선택 로직을 개선하여 테스트 유지보수성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->