### PR TITLE
test(e2e): upgrade @grafana/plugin-e2e to 3.5.1 for Grafana 13 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "^7.0.0",
-    "@grafana/plugin-e2e": "^1.6.1",
+    "@grafana/plugin-e2e": "^3.5.1",
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@playwright/test": "^1.45.1",
+    "@playwright/test": "^1.52.0",
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",

--- a/tests/query/queryEdiyor.spec.ts
+++ b/tests/query/queryEdiyor.spec.ts
@@ -1,6 +1,25 @@
 import { expect, test } from '@grafana/plugin-e2e';
+import type { Locator } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
+
+// Grafana 10.4.5+ renders the RadioButtonGroup with a visible <label> and a
+// stacked opacity:0 <input>, so Playwright's `.check()` on the native input
+// times out (waits for visibility) and a plain `.click()` on the label is
+// blocked by the input's pointer-event interception. Use `force: true` to
+// click the visible label directly. Fall back to the old plain-text path for
+// pre-10.4.5 Grafana (no label-wrapped radios).
+const selectQueryMode = async (row: Locator, mode: string) => {
+  const label = row
+    .getByLabel('query-mode')
+    .locator('label')
+    .filter({ hasText: new RegExp(`^${mode}\\s*$`) });
+  if ((await label.count()) > 0) {
+    await label.click({ force: true });
+    return;
+  }
+  await row.getByText(mode, { exact: true }).check();
+};
 
 // 대시보드 버전 목록 가져오기
 const getDashboardVersions = () => {
@@ -28,12 +47,7 @@ test('time series', async ({ readProvisionedDataSource, explorePage, page }) => 
   await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
 
-  let queryMode =  explorePage.getQueryEditorRow('A').getByLabel('query-mode').getByLabel('Time Series')
-  // for grafana version < 10.4.5
-  if(await queryMode.count()==0){
-    queryMode =  explorePage.getQueryEditorRow('A').getByText('Time Series',{exact: true})
-  }
-  await queryMode.check()
+  await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Time Series');
 
   // account select
   await explorePage.getQueryEditorRow('A').getByRole('button', { name: 'Account Select' }).click();
@@ -68,12 +82,8 @@ test('table', async ({ readProvisionedDataSource, explorePage, page }) => {
 
   await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
-  let queryMode =  explorePage.getQueryEditorRow('A').getByLabel('query-mode').getByLabel('Table')
-  // for grafana version < 10.4.5
-  if(await queryMode.count()==0){
-    queryMode =  explorePage.getQueryEditorRow('A').getByText('Table',{exact: true})
-  }
-  await queryMode.check()  // account select
+  await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Table');
+  // account select
   await explorePage.getQueryEditorRow('A').getByRole('button', { name: 'Account Select' }).click();
   await page.getByText('Default Account for Firebase').click();
   await page.getByText('gitblog - GA4').click();
@@ -106,12 +116,8 @@ test('realtime', async ({ readProvisionedDataSource, explorePage, page }) => {
 
   await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
-  let queryMode =  explorePage.getQueryEditorRow('A').getByLabel('query-mode').getByLabel('Realtime')
-  // for grafana version < 10.4.5
-  if(await queryMode.count()==0){
-    queryMode =  explorePage.getQueryEditorRow('A').getByText('Realtime',{exact: true})
-  }
-  await queryMode.check()  // account select
+  await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Realtime');
+  // account select
   await explorePage.getQueryEditorRow('A').getByRole('button', { name: 'Account Select' }).click();
   await page.getByText('Default Account for Firebase').click();
   await page.getByText('gitblog - GA4').click();

--- a/tests/query/queryEdiyor.spec.ts
+++ b/tests/query/queryEdiyor.spec.ts
@@ -20,12 +20,22 @@ const selectQueryMode = async (row: Locator, mode: string) => {
     .locator('label')
     .filter({ hasText: new RegExp(`^${mode}\\s*$`) });
   const legacyText = row.getByText(mode, { exact: true });
-  await expect(label.or(legacyText).first()).toBeVisible();
+  await expect(label.or(legacyText).first()).toBeVisible({ timeout: 15000 });
   if ((await label.count()) > 0) {
     await label.click({ force: true });
     return;
   }
   await legacyText.check();
+};
+
+// plugin-e2e >= 2.0 dropped `waitUntil: 'networkidle'` from GrafanaPage.navigate()
+// in favor of `'load'`, so when gotoDashboardPage/explorePage returns the initial
+// panel queries may still be in flight and the scenes-based dashboard (Grafana 11+)
+// may not be ready to react to refresh/datasource selection. Replicate the v1.6.x
+// behavior by explicitly waiting for the network to settle; the catch swallows the
+// harmless timeout on dashboards that keep polling (e.g. live data).
+const waitForPageSettle = async (page: import('@playwright/test').Page) => {
+  await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 };
 
 // 대시보드 버전 목록 가져오기
@@ -39,13 +49,15 @@ const getDashboardVersions = () => {
 
 // 각 버전별 마이그레이션 테스트
 getDashboardVersions().forEach(version => {
-  test(`${version} migration test`, async ({ readProvisionedDataSource, readProvisionedDashboard, gotoDashboardPage }) => {
+  test(`${version} migration test`, async ({ readProvisionedDataSource, readProvisionedDashboard, gotoDashboardPage, page }) => {
     const dashboard = await readProvisionedDashboard({fileName: `${version}.json`});
     const dashboardPage = await gotoDashboardPage({uid: dashboard.uid});
-    // waitForQueryDataResponse must be set up before refreshDashboard triggers the query,
-    // otherwise the response can arrive before the listener attaches (plugin-e2e >= 2.0
-    // dropped networkidle on navigate, so the initial query is no longer guaranteed to be
-    // complete when gotoDashboardPage returns).
+    // Wait for the initial dashboard render/hydration to settle. Without this,
+    // Grafana 11/12 scenes are not yet ready to react to the refresh click and
+    // no /api/ds/query request is emitted.
+    await waitForPageSettle(page);
+    // Attach the listener BEFORE clicking refresh so we don't miss the response
+    // to a fast-firing query.
     const responsePromise = dashboardPage.waitForQueryDataResponse();
     await dashboardPage.refreshDashboard();
     await expect(responsePromise).toBeOK();
@@ -57,6 +69,7 @@ test('time series', async ({ readProvisionedDataSource, explorePage, page }) => 
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
 
   await explorePage.datasource.set(ds.name);
+  await waitForPageSettle(page);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
 
   await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Time Series');
@@ -93,6 +106,7 @@ test('table', async ({ readProvisionedDataSource, explorePage, page }) => {
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
 
   await explorePage.datasource.set(ds.name);
+  await waitForPageSettle(page);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
   await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Table');
   // account select
@@ -127,6 +141,7 @@ test('realtime', async ({ readProvisionedDataSource, explorePage, page }) => {
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
 
   await explorePage.datasource.set(ds.name);
+  await waitForPageSettle(page);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
   await selectQueryMode(explorePage.getQueryEditorRow('A'), 'Realtime');
   // account select

--- a/tests/query/queryEdiyor.spec.ts
+++ b/tests/query/queryEdiyor.spec.ts
@@ -9,16 +9,23 @@ import * as path from 'path';
 // blocked by the input's pointer-event interception. Use `force: true` to
 // click the visible label directly. Fall back to the old plain-text path for
 // pre-10.4.5 Grafana (no label-wrapped radios).
+//
+// The `count()` check is a snapshot of the current DOM and does not wait -
+// plugin-e2e >= 2.0 no longer uses networkidle, so the datasource editor can
+// still be rendering when we reach this helper. Wait for either the radio
+// group or the legacy text to actually appear before branching.
 const selectQueryMode = async (row: Locator, mode: string) => {
   const label = row
     .getByLabel('query-mode')
     .locator('label')
     .filter({ hasText: new RegExp(`^${mode}\\s*$`) });
+  const legacyText = row.getByText(mode, { exact: true });
+  await expect(label.or(legacyText).first()).toBeVisible();
   if ((await label.count()) > 0) {
     await label.click({ force: true });
     return;
   }
-  await row.getByText(mode, { exact: true }).check();
+  await legacyText.check();
 };
 
 // 대시보드 버전 목록 가져오기

--- a/tests/query/queryEdiyor.spec.ts
+++ b/tests/query/queryEdiyor.spec.ts
@@ -35,8 +35,13 @@ getDashboardVersions().forEach(version => {
   test(`${version} migration test`, async ({ readProvisionedDataSource, readProvisionedDashboard, gotoDashboardPage }) => {
     const dashboard = await readProvisionedDashboard({fileName: `${version}.json`});
     const dashboardPage = await gotoDashboardPage({uid: dashboard.uid});
+    // waitForQueryDataResponse must be set up before refreshDashboard triggers the query,
+    // otherwise the response can arrive before the listener attaches (plugin-e2e >= 2.0
+    // dropped networkidle on navigate, so the initial query is no longer guaranteed to be
+    // complete when gotoDashboardPage returns).
+    const responsePromise = dashboardPage.waitForQueryDataResponse();
     await dashboardPage.refreshDashboard();
-    await expect(dashboardPage.waitForQueryDataResponse()).toBeOK();
+    await expect(responsePromise).toBeOK();
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,6 +637,15 @@
     tslib "2.6.0"
     typescript "4.8.4"
 
+"@grafana/e2e-selectors@13.1.0-24448182242":
+  version "13.1.0-24448182242"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24448182242.tgz#b74c928bbe762fd491aac106817717ebcd50993d"
+  integrity sha512-C8VxaFh4PGWhPBOwol3Fo0UBp1//7XNnjg7WG+t3p0P8Q2cw5HZ2NgQt1OFq9radjmWEc3DJQZvxoelI4TIOJA==
+  dependencies:
+    semver "^7.7.0"
+    tslib "2.8.1"
+    typescript "5.9.2"
+
 "@grafana/eslint-config@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/@grafana/eslint-config/-/eslint-config-7.0.0.tgz"
@@ -668,13 +677,14 @@
     ua-parser-js "^1.0.32"
     web-vitals "^3.1.1"
 
-"@grafana/plugin-e2e@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-1.6.1.tgz#51c4f9d32f5d92e38061f09f5bcaa9d5070d64b5"
-  integrity sha512-1Ww1luGFKeytiAhbg321+z8n0yZ5ARTkUgSN4YdRkupHThwi+pysqGmmiy9tJyewyqkZMt8maawL6gK2qyTKHA==
+"@grafana/plugin-e2e@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-3.5.1.tgz#7bf2c38634a1f754a77023c8f4c2d8fa55af4790"
+  integrity sha512-iYId7j9Vg0P5t2ciHTsu0Rp7S268qdjdIWhkP42AMTo/M3JhC4UWKzYOodvjekmWr+9TNOGph7FLmzcf26WWNA==
   dependencies:
+    "@grafana/e2e-selectors" "13.1.0-24448182242"
     semver "^7.5.4"
-    uuid "^9.0.1"
+    uuid "^13.0.0"
     yaml "^2.3.4"
 
 "@grafana/runtime@10.2.2":
@@ -1277,12 +1287,12 @@
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@^1.45.1":
-  version "1.45.1"
-  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz"
-  integrity sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==
+"@playwright/test@^1.52.0":
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
   dependencies:
-    playwright "1.45.1"
+    playwright "1.59.1"
 
 "@popperjs/core@2.11.8", "@popperjs/core@^2.11.5":
   version "2.11.8"
@@ -6483,17 +6493,17 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.45.1:
-  version "1.45.1"
-  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz"
-  integrity sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
 
-playwright@1.45.1:
-  version "1.45.1"
-  resolved "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz"
-  integrity sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==
+playwright@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
   dependencies:
-    playwright-core "1.45.1"
+    playwright-core "1.59.1"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -7470,6 +7480,11 @@ semver@^7.5.3:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.7.0:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
 serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
   version "6.0.2"
   resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz"
@@ -8192,6 +8207,11 @@ tslib@2.6.2, tslib@^2.1.0, tslib@^2.4.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
+tslib@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
@@ -8290,6 +8310,11 @@ typescript@5.2.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
+typescript@5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+
 ua-parser-js@^1.0.32:
   version "1.0.38"
   resolved "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz"
@@ -8368,10 +8393,10 @@ uuid@9.0.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+uuid@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
+  integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Summary
Builds on #159. PR #159 fixed the query-mode radio button for Grafana 10.4.5+, which unblocked the 10.3.12 and 11.3.9 jobs, but #159's CI still shows:

| 버전 | 결과 |
|---|---|
| 9.0.8 / 10.3.12 / 11.3.9 | ✅ |
| 13.0.1 | ❌ failure (~6분) |
| 12.2.8 / 9.3.16 | ⏱️ 60분 workflow timeout (report artifact 생성 안 됨) |

## Root cause (13.0.1)
`@grafana/plugin-e2e@1.6.1`은 2024년 초 버전으로, Grafana 13의 dashboard layout/DOM 변경을 모릅니다. Grafana 13 공식 지원은 `@grafana/plugin-e2e@3.5.0`에서 추가됐습니다. 라디오버튼 자체는 #159의 패치로 클릭되지만, 이후 `explorePage` / `getQueryEditorRow` / `timeSeriesPanel.waitForQueryDataResponse` 등의 픽스처가 Grafana 13 DOM과 맞지 않아 실패하는 것으로 추정됩니다.

## Changes
- `@grafana/plugin-e2e`: `^1.6.1` → `^3.5.1`
- `@playwright/test`: `^1.45.1` → `^1.52.0` (plugin-e2e v3의 peerDependency)
- `#159`의 query-mode radio 패치 포함 (cherry-pick)

## API 호환성 확인
테스트에서 사용하는 public API는 v1 → v3에서 모두 유지되어 테스트 코드 수정 불필요:
- `explorePage` 픽스처와 `.datasource.set()`, `.timeRange.set()`, `.getQueryEditorRow()`, `.timeSeriesPanel.waitForQueryDataResponse()`
- `readProvisionedDataSource`, `readProvisionedDashboard`, `gotoDashboardPage`
- `createDataSourceConfigPage`, `gotoDataSourceConfigPage`, `saveAndTest`
- `expect(...).toBeOK()`, `toHaveAlert()`

`plugin-e2e@3.5.1` engines: `node >=20 <=24` — `.nvmrc`(=20)와 호환.

## Local verification
- `yarn install` ✅
- `yarn typecheck` ✅
- `yarn build` ✅
- e2e 실행은 GA credentials가 필요하므로 CI에서 검증 예정

## Test plan
- [ ] Grafana 13.0.1 CI 통과
- [ ] Grafana 12.2.8 CI 통과 (또는 60분 타임아웃이 풀리는지 확인)
- [ ] Grafana 11.3.9, 10.3.12, 9.0.8 regression 없는지 확인
- [ ] Grafana 9.3.16 60분 타임아웃이 계속되면 인프라/도커 이슈로 별도 조사 필요

## 남는 이슈
**9.3.16 / 12.2.8의 60분 타임아웃은 별도 이슈일 가능성**
두 job은 `playwright-report` 아티팩트조차 생성하지 못했으므로 실제 테스트 실행에 들어가기 전/도중에 hang한 것으로 보입니다. 이 PR이 13.0.1을 해결해도 두 버전이 여전히 timeout이라면:
- 실패 job의 raw log / last line 확인 필요
- `src/plugin.json`의 `grafanaDependency: ">=9.0.0"` 범위 조정으로 matrix 축소 검토

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 도구 버전을 업데이트했습니다.

* **Tests**
  * 쿼리 편집기 테스트 안정성을 개선하고 헬퍼 함수를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->