### PR TITLE
test(e2e): fix query-mode selector for Grafana 12+ and dismiss "What's new" modal for 13+

### DIFF
--- a/tests/config/configEditor.spec.ts
+++ b/tests/config/configEditor.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@grafana/plugin-e2e';
 import { GADataSourceOptions, GASecureJsonData } from '../../src/types';
+import { dismissWhatsNewModal } from '../utils';
 
 test('"Save & test" should be successful when configuration is valid', async ({
   gotoDataSourceConfigPage,
@@ -8,6 +9,7 @@ test('"Save & test" should be successful when configuration is valid', async ({
 }) => {
   const ds = await readProvisionedDataSource<GADataSourceOptions, GASecureJsonData>({ fileName: 'datasources.yml' });
   const configPage = await gotoDataSourceConfigPage(ds.uid);
+  await dismissWhatsNewModal(page);
   const resetButton =  await page.getByText('Upload another JWT file').isVisible()
   if(resetButton){
     await page.getByText('Upload another JWT file').click()
@@ -23,6 +25,7 @@ test('"Save & test" should fail when configuration is invalid', async ({
 }) => {
   const ds = await readProvisionedDataSource<GADataSourceOptions, GASecureJsonData>({ fileName: 'datasources.yml' });
   const configPage = await createDataSourceConfigPage({ type: ds.type, deleteDataSourceAfterTest: true });
+  await dismissWhatsNewModal(page);
   await page.locator('input[accept="application/json"]').setInputFiles('./tests/credentials/grafana-fail.json')
   await expect(configPage.saveAndTest()).not.toBeOK();
   await expect(configPage).toHaveAlert('error');

--- a/tests/query/queryEdiyor.spec.ts
+++ b/tests/query/queryEdiyor.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@grafana/plugin-e2e';
 import type { Locator } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
+import { dismissWhatsNewModal } from '../utils';
 
 // Grafana 10.4.5+ renders the RadioButtonGroup with a visible <label> and a
 // stacked opacity:0 <input>, so Playwright's `.check()` on the native input
@@ -52,6 +53,7 @@ getDashboardVersions().forEach(version => {
   test(`${version} migration test`, async ({ readProvisionedDataSource, readProvisionedDashboard, gotoDashboardPage, page }) => {
     const dashboard = await readProvisionedDashboard({fileName: `${version}.json`});
     const dashboardPage = await gotoDashboardPage({uid: dashboard.uid});
+    await dismissWhatsNewModal(page);
     // Wait for the initial dashboard render/hydration to settle. Without this,
     // Grafana 11/12 scenes are not yet ready to react to the refresh click and
     // no /api/ds/query request is emitted.
@@ -68,6 +70,7 @@ test('time series', async ({ readProvisionedDataSource, explorePage, page }) => 
   // default settings
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
 
+  await dismissWhatsNewModal(page);
   await explorePage.datasource.set(ds.name);
   await waitForPageSettle(page);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
@@ -105,6 +108,7 @@ test('table', async ({ readProvisionedDataSource, explorePage, page }) => {
   // default settings
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
 
+  await dismissWhatsNewModal(page);
   await explorePage.datasource.set(ds.name);
   await waitForPageSettle(page);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });
@@ -140,6 +144,7 @@ test('realtime', async ({ readProvisionedDataSource, explorePage, page }) => {
   // default settings
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
 
+  await dismissWhatsNewModal(page);
   await explorePage.datasource.set(ds.name);
   await waitForPageSettle(page);
   await explorePage.timeRange.set({ from: 'now-7d', to: 'now' });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,15 @@
+import type { Page } from '@playwright/test';
+
+// Grafana 13+ shows a "What's new in Grafana" announcement carousel on the
+// first authenticated page load. It mounts into #grafana-portal-container
+// with a viewport-sized scrim (z-index:1050) that intercepts pointer events,
+// so any subsequent click — including saveAndTest — times out. Dismiss it
+// before interacting with the page. Older Grafana versions don't render the
+// dialog, so the visibility check returns quickly and is a no-op.
+export const dismissWhatsNewModal = async (page: Page) => {
+  const dialog = page.getByRole('dialog', { name: /What's new in Grafana/i });
+  if (await dialog.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await dialog.getByRole('button', { name: 'Close' }).first().click();
+    await dialog.waitFor({ state: 'hidden', timeout: 5000 });
+  }
+};


### PR DESCRIPTION
## Summary
- Fix `selectQueryMode` helper to handle Grafana 10.4.5+ `RadioButtonGroup` (`<label>` + opacity:0 `<input>`) — force-clicks the visible label instead of relying on `.check()` on the hidden input. Falls back to the legacy plain-text path for pre-10.4.5 Grafana.
- Add `dismissWhatsNewModal` helper for Grafana 13+. The new "What's new in Grafana" announcement carousel mounts into `#grafana-portal-container` with a viewport-sized scrim (z-index:1050) that intercepts pointer events, causing `saveAndTest` and other clicks to time out at 30s. The helper closes it before interacting with the page; cheap no-op on older versions (`isVisible` returns false within 1.5s).

## Why
- 12.x e2e has been failing across multiple PRs (#155 / #156 / #158) with `getByText('Time Series').check()` timing out — caused by the new RadioButtonGroup DOM, not by environment/speed.
- 13.0.1 e2e fails with `locator.click: Test timeout of 30000ms exceeded` followed by `Target page, context or browser has been closed`. Trace analysis showed the Save & test button is rendered, enabled, and visible — but `document.elementFromPoint` returns the announcement-modal scrim, so Playwright never gets a stable click target.

## Local verification
Ran the full CI matrix locally on Apple Silicon (`docker compose up` → `CI=true yarn run e2e`):

| Grafana | Result | Time |
|--|--|--|
| 9.0.8 | ✅ 9 passed | 30.0s |
| 9.3.16 | ✅ 9 passed | 31.1s |
| 10.3.12 | ✅ 9 passed | 39.4s |
| 11.3.9 | ✅ 9 passed | 37.7s |
| 12.2.8 | ✅ 9 passed | 39.0s |
| 13.0.1 | ✅ 9 passed | 36.4s |

## Test plan
- [ ] CI e2e matrix passes on all 6 Grafana versions
- [ ] After merge, rebase #155 / #156 / #158 to pick up the helper and confirm their 12.2.8 / 13.0.1 jobs go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 안정성 개선을 위해 Grafana 팝업 모달 자동 처리 기능 추가
  * 쿼리 모드 선택 로직 개선으로 여러 버전에 걸친 일관된 테스트 실행 환경 구성
  * 테스트 유틸리티 함수 추가로 테스트 코드 유지보수성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->