### PR TITLE
fix(JWTConfig): correct dropzone accept format and stabilize e2e

### DIFF
--- a/src/JWTConfig.tsx
+++ b/src/JWTConfig.tsx
@@ -33,7 +33,7 @@ export function JWTConfig({ onChange, isConfigured }: Props) {
       <DropZone
         baseStyle={{ marginTop: '24px' }}
         accept={{
-          'json': ['application/json', 'json']
+          'application/json': ['.json'],
         }}
         onDrop={(acceptedFiles) => {
           const reader = new FileReader();

--- a/tests/config/configEditor.spec.ts
+++ b/tests/config/configEditor.spec.ts
@@ -15,6 +15,12 @@ test('"Save & test" should be successful when configuration is valid', async ({
     await page.getByText('Upload another JWT file').click()
   }
   await page.locator('input[accept="application/json"]').setInputFiles('./tests/credentials/grafana-success.json')
+  // setInputFiles dispatches the change event but resolves before the dropzone's
+  // FileReader → JWTConfig.onChange → React rerender chain completes. Wait for
+  // the dropzone to disappear (proves onChange fired and secureJsonData was
+  // populated) before triggering saveAndTest, otherwise the save races the
+  // credential update and CheckHealth returns 400.
+  await expect(page.getByText('Drop the file here, or click to use the file explorer')).toBeHidden();
   await expect(configPage.saveAndTest()).toBeOK();
 });
 
@@ -27,6 +33,7 @@ test('"Save & test" should fail when configuration is invalid', async ({
   const configPage = await createDataSourceConfigPage({ type: ds.type, deleteDataSourceAfterTest: true });
   await dismissWhatsNewModal(page);
   await page.locator('input[accept="application/json"]').setInputFiles('./tests/credentials/grafana-fail.json')
+  await expect(page.getByText('Drop the file here, or click to use the file explorer')).toBeHidden();
   await expect(configPage.saveAndTest()).not.toBeOK();
   await expect(configPage).toHaveAlert('error');
 });

--- a/tests/config/configEditor.spec.ts
+++ b/tests/config/configEditor.spec.ts
@@ -14,7 +14,7 @@ test('"Save & test" should be successful when configuration is valid', async ({
   if(resetButton){
     await page.getByText('Upload another JWT file').click()
   }
-  await page.locator('input[accept="application/json"]').setInputFiles('./tests/credentials/grafana-success.json')
+  await page.locator('input[type="file"][accept*="application/json"]').setInputFiles('./tests/credentials/grafana-success.json')
   // setInputFiles dispatches the change event but resolves before the dropzone's
   // FileReader → JWTConfig.onChange → React rerender chain completes. Wait for
   // the dropzone to disappear (proves onChange fired and secureJsonData was
@@ -32,7 +32,7 @@ test('"Save & test" should fail when configuration is invalid', async ({
   const ds = await readProvisionedDataSource<GADataSourceOptions, GASecureJsonData>({ fileName: 'datasources.yml' });
   const configPage = await createDataSourceConfigPage({ type: ds.type, deleteDataSourceAfterTest: true });
   await dismissWhatsNewModal(page);
-  await page.locator('input[accept="application/json"]').setInputFiles('./tests/credentials/grafana-fail.json')
+  await page.locator('input[type="file"][accept*="application/json"]').setInputFiles('./tests/credentials/grafana-fail.json')
   await expect(page.getByText('Drop the file here, or click to use the file explorer')).toBeHidden();
   await expect(configPage.saveAndTest()).not.toBeOK();
   await expect(configPage).toHaveAlert('error');
@@ -54,7 +54,7 @@ test('legacy v3 datasource config loads without crashing', async ({
   await dismissWhatsNewModal(page);
   // The JWT upload control must render — proves ConfigEditor mounted despite
   // the legacy `version: v3` value in jsonData.
-  await expect(page.locator('input[accept="application/json"]')).toBeAttached();
+  await expect(page.locator('input[type="file"][accept*="application/json"]')).toBeAttached();
 });
 
 


### PR DESCRIPTION
## Summary
- Found while diagnosing PR #164 (dependabot npm bumps). All 6 Grafana e2e jobs failed at `configEditor.spec.ts:5` with HTTP 400 from `saveAndTest()` even though source code was unchanged. Root cause was a malformed `accept` prop in JWTConfig combined with a race in the e2e test.

## Failure mechanism
1. `JWTConfig` passed a non-standard `accept` shape to react-dropzone:
   ```ts
   accept={{ 'json': ['application/json', 'json'] }}
   ```
   react-dropzone v14 expects MIME types as keys; `'json'` is neither a MIME nor an extension. The form previously worked only because `attr-accept` loose-matched the values array, and that fallback was sensitive to webpack/postcss codegen order.
2. Under PR #164's bumps (`webpack 5.94 → 5.104`, `glob 10 → 12`, `postcss 8.4.39 → 8.5.14`), the accept check started rejecting the uploaded file, so react-dropzone never called `onDrop`. `JWTConfig.onChange` never fired and `secureJsonData.jwt` stayed empty.
3. The e2e test then clicked Save & test before the upload could land — Grafana saved an empty datasource and CheckHealth returned `auth: no credentials configured`.
4. Even with a correct `accept`, the test was racy: `setInputFiles` resolves before the `FileReader → onChange → React rerender` chain completes, so the save can still beat the credential update on slower CI runners.

## Fix
- `src/JWTConfig.tsx`: use the documented shape `{ 'application/json': ['.json'] }` so the dropzone accepts JWT files regardless of bundler version.
- `tests/config/configEditor.spec.ts`: after `setInputFiles`, wait for the dropzone paragraph (`Drop the file here, or click to use the file explorer`) to disappear before invoking `saveAndTest`. That signal proves `onChange` fired and the credentials are in state. Applied to both the success and the invalid-credentials test.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [ ] After merge: rebase #164 on master and confirm e2e passes across all Grafana versions
- [ ] After merge: re-run e2e on master to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JWT 파일 업로드 시 JSON 파일 형식만 허용하도록 파일 검증이 강화되었습니다.

* **Tests**
  * 파일 업로드 후 비동기 처리가 완료될 때까지 기다리는 동기화 단계가 추가되어 구성 설정 테스트의 안정성과 신뢰성이 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackcowmoo/grafana-google-analytics-datasource/pull/166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->