### PR TITLE
feat(frontend): support accounts/properties as dashboard variables (#109)

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -1,4 +1,4 @@
-import { DataSourceInstanceSettings, ScopedVars, SelectableValue } from '@grafana/data';
+import { DataSourceInstanceSettings, MetricFindValue, ScopedVars, SelectableValue } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { CascaderOption } from '@grafana/ui';
 import { AccountSummary, GADataSourceOptions, GAMetadata, GAQuery } from './types';
@@ -166,6 +166,43 @@ export class DataSource extends DataSourceWithBackend<GAQuery, GADataSourceOptio
         return pre;
       }, []);
     });
+  }
+
+  async metricFindQuery(query: string, options?: { scopedVars?: ScopedVars }): Promise<MetricFindValue[]> {
+    const templateSrv = getTemplateSrv();
+    const interpolated = templateSrv.replace(query.trim(), options?.scopedVars);
+
+    const accountSummaries = (await this.getResource('account-summaries')).accountSummaries as AccountSummary[];
+
+    const propertiesMatch = interpolated.match(/^properties\(([^)]+)\)$/i);
+    if (propertiesMatch) {
+      const accountId = propertiesMatch[1].trim();
+      const account = accountSummaries.find(
+        (a) => a.Account === accountId || a.Account === `accounts/${accountId}`
+      );
+      return (account?.PropertySummaries ?? []).map((p) => ({
+        text: p.DisplayName,
+        value: p.Property,
+      }));
+    }
+
+    if (/^properties$/i.test(interpolated)) {
+      return accountSummaries.flatMap((a) =>
+        (a.PropertySummaries ?? []).map((p) => ({
+          text: p.DisplayName,
+          value: p.Property,
+        }))
+      );
+    }
+
+    if (/^accounts$/i.test(interpolated)) {
+      return accountSummaries.map((a) => ({
+        text: a.DisplayName,
+        value: a.Account,
+      }));
+    }
+
+    return [];
   }
 
   async getTimeDimensions(): Promise<Array<SelectableValue<string>>> {


### PR DESCRIPTION
## Summary

- Add `metricFindQuery` to `DataSource` class so GA accounts and properties can be used as Grafana dashboard variables.
- The existing `/account-summaries` resource endpoint is reused — no backend changes needed.

## Query syntax

| Variable query | Returns |
|----------------|---------|
| `accounts` | All GA accounts (text = display name, value = `accounts/XXXXXX`) |
| `properties` | All properties across all accounts |
| `properties(accounts/XXXXXX)` | Properties for a specific account |
| `properties($accountVar)` | Properties for an account selected via another variable |

## Usage example

1. Dashboard → Variables → New Variable → Type: **Query**, Data source: **Google Analytics**
2. Query: `accounts` → creates an account picker variable
3. Add a second variable with query: `properties($account)` → cascades from the first variable
4. Use `$property` in panel queries as the **Web Property ID**

## Test plan

- [x] `yarn typecheck` passes
- [ ] Manual: create `accounts` variable — confirm all GA accounts appear
- [ ] Manual: create `properties($account)` variable — confirm it filters by selected account
- [ ] Manual: create `properties` variable — confirm all properties from all accounts appear

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계정 및 속성 필터링을 지원하는 템플릿 변수 쿼리 기능 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackcowmoo/grafana-google-analytics-datasource/pull/167)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->