### PR TITLE
feat(filter): complete GA4 filter UI overhaul + MetricFilter support

### DIFF
--- a/pkg/gav4/client.go
+++ b/pkg/gav4/client.go
@@ -98,6 +98,9 @@ func (client *GoogleClient) getReport(query model.QueryModel) (*analyticsdata.Ru
 	if !(query.DimensionFilter.OrGroup == nil && query.DimensionFilter.AndGroup == nil && query.DimensionFilter.Filter == nil && query.DimensionFilter.NotExpression == nil) {
 		req.DimensionFilter = &query.DimensionFilter
 	}
+	if !(query.MetricFilter.OrGroup == nil && query.MetricFilter.AndGroup == nil && query.MetricFilter.Filter == nil && query.MetricFilter.NotExpression == nil) {
+		req.MetricFilter = &query.MetricFilter
+	}
 	log.DefaultLogger.Debug("Doing GET request from analytics reporting", "req", req)
 	// Call the BatchGet method and return the response.
 	report, err := client.analyticsdata.Properties.RunReport(query.WebPropertyID, &req).Do()
@@ -182,6 +185,9 @@ func (client *GoogleClient) getRealtimeReport(query model.QueryModel) (*analytic
 	if !(query.DimensionFilter.OrGroup == nil && query.DimensionFilter.AndGroup == nil && query.DimensionFilter.Filter == nil && query.DimensionFilter.NotExpression == nil) {
 		req.DimensionFilter = &query.DimensionFilter
 	}
+	if !(query.MetricFilter.OrGroup == nil && query.MetricFilter.AndGroup == nil && query.MetricFilter.Filter == nil && query.MetricFilter.NotExpression == nil) {
+		req.MetricFilter = &query.MetricFilter
+	}
 	log.DefaultLogger.Debug("Doing GET request from analytics reporting", "req", req)
 	// Call the BatchGet method and return the response.
 	report, err := client.analyticsdata.Properties.RunRealtimeReport(query.WebPropertyID, &req).Do()
@@ -225,8 +231,8 @@ func (client *GoogleClient) getRealtimeReport(query model.QueryModel) (*analytic
 
 // 			for _, metric := range metrics {
 // 				// We have only 1 date range in the example
-// 				// So it'll always print "Date Range (0)"
-// 				// log.DefaultLogger.Defaultlog.DefaultLogger.Infof("Date Range (%d)", idx)
+// 				// So it'll always print \"Date Range (0)\"
+// 				// log.DefaultLogger.Defaultlog.DefaultLogger.Infof(\"Date Range (%d)\", idx)
 // 				for j := 0; j < len(metricHdrs) && j < len(metric.Values); j++ {
 // 					log.DefaultLogger.Debug("%s: %s", metricHdrs[j].Name, metric.Values[j])
 // 				}

--- a/pkg/gav4/client.go
+++ b/pkg/gav4/client.go
@@ -95,11 +95,11 @@ func (client *GoogleClient) getReport(query model.QueryModel) (*analyticsdata.Ru
 			},
 		}
 	}
-	if !(query.DimensionFilter.OrGroup == nil && query.DimensionFilter.AndGroup == nil && query.DimensionFilter.Filter == nil && query.DimensionFilter.NotExpression == nil) {
-		req.DimensionFilter = &query.DimensionFilter
+	if query.DimensionFilter != nil {
+		req.DimensionFilter = query.DimensionFilter
 	}
-	if !(query.MetricFilter.OrGroup == nil && query.MetricFilter.AndGroup == nil && query.MetricFilter.Filter == nil && query.MetricFilter.NotExpression == nil) {
-		req.MetricFilter = &query.MetricFilter
+	if query.MetricFilter != nil {
+		req.MetricFilter = query.MetricFilter
 	}
 	log.DefaultLogger.Debug("Doing GET request from analytics reporting", "req", req)
 	// Call the BatchGet method and return the response.
@@ -182,11 +182,11 @@ func (client *GoogleClient) getRealtimeReport(query model.QueryModel) (*analytic
 			},
 		}
 	}
-	if !(query.DimensionFilter.OrGroup == nil && query.DimensionFilter.AndGroup == nil && query.DimensionFilter.Filter == nil && query.DimensionFilter.NotExpression == nil) {
-		req.DimensionFilter = &query.DimensionFilter
+	if query.DimensionFilter != nil {
+		req.DimensionFilter = query.DimensionFilter
 	}
-	if !(query.MetricFilter.OrGroup == nil && query.MetricFilter.AndGroup == nil && query.MetricFilter.Filter == nil && query.MetricFilter.NotExpression == nil) {
-		req.MetricFilter = &query.MetricFilter
+	if query.MetricFilter != nil {
+		req.MetricFilter = query.MetricFilter
 	}
 	log.DefaultLogger.Debug("Doing GET request from analytics reporting", "req", req)
 	// Call the BatchGet method and return the response.

--- a/pkg/gav4/client.go
+++ b/pkg/gav4/client.go
@@ -21,6 +21,14 @@ type GoogleClient struct {
 	analyticsadmin *analyticsadmin.Service
 }
 
+// filterHasContent returns true only when the filter expression contains at
+// least one meaningful field.  The frontend sends {} for "no filter", which
+// JSON-decodes to a non-nil pointer with all fields nil; we must not forward
+// that empty expression to the GA4 API.
+func filterHasContent(f *analyticsdata.FilterExpression) bool {
+	return f != nil && (f.Filter != nil || f.AndGroup != nil || f.OrGroup != nil || f.NotExpression != nil)
+}
+
 func NewGoogleClient(ctx context.Context, config *setting.DatasourceSecretSettings) (*GoogleClient, error) {
 	resolved, err := auth.Resolve(config)
 	if err != nil {
@@ -95,10 +103,10 @@ func (client *GoogleClient) getReport(query model.QueryModel) (*analyticsdata.Ru
 			},
 		}
 	}
-	if query.DimensionFilter != nil {
+	if filterHasContent(query.DimensionFilter) {
 		req.DimensionFilter = query.DimensionFilter
 	}
-	if query.MetricFilter != nil {
+	if filterHasContent(query.MetricFilter) {
 		req.MetricFilter = query.MetricFilter
 	}
 	log.DefaultLogger.Debug("Doing GET request from analytics reporting", "req", req)
@@ -182,10 +190,10 @@ func (client *GoogleClient) getRealtimeReport(query model.QueryModel) (*analytic
 			},
 		}
 	}
-	if query.DimensionFilter != nil {
+	if filterHasContent(query.DimensionFilter) {
 		req.DimensionFilter = query.DimensionFilter
 	}
-	if query.MetricFilter != nil {
+	if filterHasContent(query.MetricFilter) {
 		req.MetricFilter = query.MetricFilter
 	}
 	log.DefaultLogger.Debug("Doing GET request from analytics reporting", "req", req)
@@ -231,8 +239,8 @@ func (client *GoogleClient) getRealtimeReport(query model.QueryModel) (*analytic
 
 // 			for _, metric := range metrics {
 // 				// We have only 1 date range in the example
-// 				// So it'll always print \"Date Range (0)\"
-// 				// log.DefaultLogger.Defaultlog.DefaultLogger.Infof(\"Date Range (%d)\", idx)
+// 				// So it'll always print "Date Range (%d)"
+// 				// log.DefaultLogger.Defaultlog.DefaultLogger.Infof("Date Range (%d)", idx)
 // 				for j := 0; j < len(metricHdrs) && j < len(metric.Values); j++ {
 // 					log.DefaultLogger.Debug("%s: %s", metricHdrs[j].Name, metric.Values[j])
 // 				}

--- a/pkg/model/models.go
+++ b/pkg/model/models.go
@@ -134,8 +134,8 @@ type QueryModel struct {
 	Offset            int64        `json:"offset,omitempty"`
 	Mode              QueryMode    `json:"mode,omitempty"`
 	ServiceLevel      ServiceLevel `json:"serviceLevel,omitempty"`
-	DimensionFilter analyticsdata.FilterExpression `json:"dimensionFilter,omitempty"`
-	MetricFilter    analyticsdata.FilterExpression `json:"metricFilter,omitempty"`
+	DimensionFilter *analyticsdata.FilterExpression `json:"dimensionFilter,omitempty"`
+	MetricFilter    *analyticsdata.FilterExpression `json:"metricFilter,omitempty"`
 
 	From time.Time
 	To   time.Time

--- a/pkg/model/models.go
+++ b/pkg/model/models.go
@@ -134,8 +134,8 @@ type QueryModel struct {
 	Offset            int64        `json:"offset,omitempty"`
 	Mode              QueryMode    `json:"mode,omitempty"`
 	ServiceLevel      ServiceLevel `json:"serviceLevel,omitempty"`
-	// TODO type convert
 	DimensionFilter analyticsdata.FilterExpression `json:"dimensionFilter,omitempty"`
+	MetricFilter    analyticsdata.FilterExpression `json:"metricFilter,omitempty"`
 
 	From time.Time
 	To   time.Time

--- a/pkg/model/models_test.go
+++ b/pkg/model/models_test.go
@@ -57,8 +57,8 @@ func TestQueryModel_FilterRoundTrip(t *testing.T) {
 	}
 	qm := QueryModel{
 		WebPropertyID:   "properties/123",
-		DimensionFilter: filter,
-		MetricFilter:    filter,
+		DimensionFilter: &filter,
+		MetricFilter:    &filter,
 	}
 
 	b, err := json.Marshal(qm)
@@ -71,10 +71,10 @@ func TestQueryModel_FilterRoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	if got.DimensionFilter.Filter == nil || got.DimensionFilter.Filter.FieldName != "country" {
+	if got.DimensionFilter == nil || got.DimensionFilter.Filter == nil || got.DimensionFilter.Filter.FieldName != "country" {
 		t.Errorf("DimensionFilter round-trip failed: %+v", got.DimensionFilter)
 	}
-	if got.MetricFilter.Filter == nil || got.MetricFilter.Filter.FieldName != "country" {
+	if got.MetricFilter == nil || got.MetricFilter.Filter == nil || got.MetricFilter.Filter.FieldName != "country" {
 		t.Errorf("MetricFilter round-trip failed: %+v", got.MetricFilter)
 	}
 }

--- a/pkg/model/models_test.go
+++ b/pkg/model/models_test.go
@@ -1,6 +1,11 @@
 package model
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
+)
 
 func TestGetColumnType(t *testing.T) {
 	numberTypes := []string{
@@ -34,5 +39,68 @@ func TestNewColumnDefinition(t *testing.T) {
 	}
 	if cd.GetType() != ColumTypeNumber {
 		t.Errorf("GetType() = %q, want %q", cd.GetType(), ColumTypeNumber)
+	}
+}
+
+// TestQueryModel_FilterRoundTrip verifies that DimensionFilter and MetricFilter
+// survive a JSON round-trip without loss, which is the path taken when the
+// frontend serialises the query and the backend deserialises it.
+func TestQueryModel_FilterRoundTrip(t *testing.T) {
+	filter := analyticsdata.FilterExpression{
+		Filter: &analyticsdata.Filter{
+			FieldName: "country",
+			StringFilter: &analyticsdata.StringFilter{
+				MatchType: "EXACT",
+				Value:     "US",
+			},
+		},
+	}
+	qm := QueryModel{
+		WebPropertyID:   "properties/123",
+		DimensionFilter: filter,
+		MetricFilter:    filter,
+	}
+
+	b, err := json.Marshal(qm)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got QueryModel
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.DimensionFilter.Filter == nil || got.DimensionFilter.Filter.FieldName != "country" {
+		t.Errorf("DimensionFilter round-trip failed: %+v", got.DimensionFilter)
+	}
+	if got.MetricFilter.Filter == nil || got.MetricFilter.Filter.FieldName != "country" {
+		t.Errorf("MetricFilter round-trip failed: %+v", got.MetricFilter)
+	}
+}
+
+// TestQueryModel_EmptyFilterIsOmitted verifies that zero-value filters are
+// omitted from JSON so the backend nil-checks in client.go behave correctly.
+func TestQueryModel_EmptyFilterIsOmitted(t *testing.T) {
+	qm := QueryModel{WebPropertyID: "properties/456"}
+
+	b, err := json.Marshal(qm)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Both filter fields carry omitempty — they must not appear in the output
+	// when no filter is set, so the nil-checks in getReport / getRealtimeReport
+	// keep working correctly.
+	if _, ok := raw["dimensionFilter"]; ok {
+		t.Error("expected dimensionFilter to be omitted when zero, but it was present")
+	}
+	if _, ok := raw["metricFilter"]; ok {
+		t.Error("expected metricFilter to be omitted when zero, but it was present")
 	}
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,15 @@ export default defineConfig({
         storageState: 'playwright/.auth/admin.json',
       },
       dependencies: ['config'],
-    }
+    },
+    {
+      name: 'features',
+      testDir: './tests/features',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['auth'],
+    },
   ],
 });

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -1,6 +1,6 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { DataSource } from './DataSource';
-import { GADataSourceOptions, GADimensionFilterType, GAFilterExpression, GAQuery } from './types';
+import { GADataSourceOptions, GADimensionFilterType, GAFilterExpression, GANumericFilterOperation, GAQuery, GAStringFilterMatchType } from './types';
 
 jest.mock('@grafana/runtime', () => {
   // Inline the TemplateSrv stub here because jest.mock factories cannot
@@ -139,5 +139,76 @@ describe('DataSource.applyTemplateVariables', () => {
     const query = makeQuery({ dimensionFilter: undefined as unknown as GAFilterExpression });
 
     expect(() => ds.applyTemplateVariables(query, {})).not.toThrow();
+  });
+
+  it('interpolates metricFilter inListFilter variables', () => {
+    setVars({ segments: ['organic', 'cpc'] });
+    const ds = makeDataSource();
+    const metricFilter: GAFilterExpression = {
+      filter: {
+        fieldName: 'sessionDefaultChannelGrouping',
+        filterType: GADimensionFilterType.IN_LIST,
+        inListFilter: { values: ['$segments'], caseSensitive: false },
+      },
+    };
+    const query = makeQuery({ metricFilter });
+
+    const interpolated = ds.applyTemplateVariables(query, {});
+
+    expect(interpolated.metricFilter.filter.inListFilter.values).toEqual(['organic', 'cpc']);
+  });
+
+  it('does not mutate the input metricFilter (deep-clones before interpolation)', () => {
+    setVars({ seg: ['a', 'b'] });
+    const ds = makeDataSource();
+    const inputFilter: GAFilterExpression = {
+      filter: {
+        fieldName: 'sessionMedium',
+        filterType: GADimensionFilterType.IN_LIST,
+        inListFilter: { values: ['$seg'], caseSensitive: false },
+      },
+    };
+    const snapshot = JSON.parse(JSON.stringify(inputFilter));
+    const query = makeQuery({ metricFilter: inputFilter });
+
+    ds.applyTemplateVariables(query, {});
+
+    expect(inputFilter).toEqual(snapshot);
+  });
+
+  it('returns undefined metricFilter when query has no metricFilter', () => {
+    setVars({});
+    const ds = makeDataSource();
+    const query = makeQuery({ metricFilter: undefined });
+
+    const interpolated = ds.applyTemplateVariables(query, {});
+
+    expect(interpolated.metricFilter).toBeUndefined();
+  });
+
+  it('interpolates both dimensionFilter and metricFilter independently', () => {
+    setVars({ dim: 'US', met: 'organic' });
+    const ds = makeDataSource();
+    const query = makeQuery({
+      dimensionFilter: {
+        filter: {
+          fieldName: 'country',
+          filterType: GADimensionFilterType.STRING,
+          stringFilter: { matchType: GAStringFilterMatchType.EXACT, value: '$dim', caseSensitive: false },
+        },
+      },
+      metricFilter: {
+        filter: {
+          fieldName: 'sessionMedium',
+          filterType: GADimensionFilterType.STRING,
+          stringFilter: { matchType: GAStringFilterMatchType.EXACT, value: '$met', caseSensitive: false },
+        },
+      },
+    });
+
+    const interpolated = ds.applyTemplateVariables(query, {});
+
+    expect(interpolated.dimensionFilter.filter.stringFilter.value).toBe('US');
+    expect(interpolated.metricFilter.filter.stringFilter.value).toBe('organic');
   });
 });

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -1,6 +1,6 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { DataSource } from './DataSource';
-import { GADataSourceOptions, GADimensionFilterType, GAFilterExpression, GANumericFilterOperation, GAQuery, GAStringFilterMatchType } from './types';
+import { GADataSourceOptions, GADimensionFilterType, GAFilterExpression, GAQuery, GAStringFilterMatchType } from './types';
 
 jest.mock('@grafana/runtime', () => {
   // Inline the TemplateSrv stub here because jest.mock factories cannot

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -18,6 +18,11 @@ export class DataSource extends DataSourceWithBackend<GAQuery, GADataSourceOptio
       : undefined;
     interpolateFilterExpression(templateSrv, dimensionFilter, scopedVars);
 
+    const metricFilter: GAFilterExpression | undefined = query.metricFilter
+      ? JSON.parse(JSON.stringify(query.metricFilter))
+      : undefined;
+    interpolateFilterExpression(templateSrv, metricFilter, scopedVars);
+
     // Apply template variable interpolation to webPropertyId
     const webPropertyId = templateSrv.replace(query.webPropertyId, scopedVars);
 
@@ -25,6 +30,7 @@ export class DataSource extends DataSourceWithBackend<GAQuery, GADataSourceOptio
       ...query,
       webPropertyId,
       dimensionFilter,
+      metricFilter,
     };
   }
   async getAccountSummaries(): Promise<CascaderOption[]> {

--- a/src/Filter.tsx
+++ b/src/Filter.tsx
@@ -96,7 +96,7 @@ function numericValueStr(v?: GANumericValue): string {
   if (!v) { return ''; }
   // int64Value is a string like "0", "123" — non-empty means it was explicitly set
   if (v.int64Value != null && v.int64Value !== '') { return v.int64Value; }
-  if (v.doubleValue != null && v.doubleValue !== 0) { return String(v.doubleValue); }
+  if (v.doubleValue != null) { return String(v.doubleValue); }
   return '';
 }
 

--- a/src/Filter.tsx
+++ b/src/Filter.tsx
@@ -1,234 +1,505 @@
-// cursor ai로 작성됨
-import { SelectableValue } from '@grafana/data';
-import { Button, FieldSet, HorizontalGroup, Input, RadioButtonGroup, Select, VerticalGroup } from '@grafana/ui';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { css } from '@emotion/css';
+import {
+  AsyncSelect,
+  IconButton,
+  InlineSwitch,
+  Input,
+  Select,
+  TagsInput,
+  useStyles2,
+} from '@grafana/ui';
 import React from 'react';
-import { GADimensionFilterType, GAFilter, GAFilterExpression, GAFilterExpressionList, GAInListFilter, GAStringFilter, GAStringFilterMatchType } from 'types';
+import {
+  GABetweenFilter,
+  GADimensionFilterType,
+  GAFilter,
+  GAFilterExpression,
+  GAFilterExpressionList,
+  GAInListFilter,
+  GANumericFilter,
+  GANumericFilterOperation,
+  GANumericValue,
+  GAStringFilter,
+  GAStringFilterMatchType,
+} from 'types';
 
-interface Props {
+export type LoadFieldsFn = (query: string) => Promise<Array<SelectableValue<string>>>;
+
+export interface GAFilterExpressionComponentProps {
   expression: GAFilterExpression;
-  onChange: (expression: GAFilterExpression) => void;
-  onDelete?: () => void;  // New prop added
-  selectedDimensions: Array<SelectableValue<string>>; // New prop added
+  onChange: (expr: GAFilterExpression) => void;
+  onDelete?: () => void;
+  loadFields: LoadFieldsFn;
+  /** Visual nesting depth — drives indentation and border colour */
+  depth?: number;
 }
 
-export const GAFilterExpressionComponent: React.FC<Props> = ({ expression = {}, onChange, onDelete, selectedDimensions }) => {
-  const expressionTypes: Array<SelectableValue<string>> = [
-    { label: 'no filter', value: 'none' },
-    { label: 'AND', value: 'andGroup' },
-    { label: 'OR', value: 'orGroup' },
-    { label: 'NOT', value: 'notExpression' },
-    { label: 'FILTER', value: 'filter' },
+// ─── option arrays ────────────────────────────────────────────────────────────
+
+const EXPR_TYPE_OPTIONS: Array<SelectableValue<string>> = [
+  { label: 'No filter',     value: 'none'          },
+  { label: 'Filter',        value: 'filter'        },
+  { label: 'AND group',     value: 'andGroup'      },
+  { label: 'OR group',      value: 'orGroup'       },
+  { label: 'NOT',           value: 'notExpression' },
+];
+
+const FILTER_TYPE_OPTIONS: Array<SelectableValue<GADimensionFilterType>> = [
+  { label: 'String',  value: GADimensionFilterType.STRING  },
+  { label: 'In list', value: GADimensionFilterType.IN_LIST },
+  { label: 'Numeric', value: GADimensionFilterType.NUMERIC },
+  { label: 'Between', value: GADimensionFilterType.BETWEEN },
+  { label: 'Empty',   value: GADimensionFilterType.EMPTY   },
+];
+
+const STRING_MATCH_OPTIONS: Array<SelectableValue<GAStringFilterMatchType>> = [
+  { label: 'Exact',          value: GAStringFilterMatchType.EXACT          },
+  { label: 'Begins with',    value: GAStringFilterMatchType.BEGINS_WITH    },
+  { label: 'Ends with',      value: GAStringFilterMatchType.ENDS_WITH      },
+  { label: 'Contains',       value: GAStringFilterMatchType.CONTAINS       },
+  { label: 'Full regexp',    value: GAStringFilterMatchType.FULL_REGEXP    },
+  { label: 'Partial regexp', value: GAStringFilterMatchType.PARTIAL_REGEXP },
+];
+
+const NUMERIC_OP_OPTIONS: Array<SelectableValue<GANumericFilterOperation>> = [
+  { label: '=',  value: GANumericFilterOperation.EQUAL                 },
+  { label: '<',  value: GANumericFilterOperation.LESS_THAN             },
+  { label: '≤',  value: GANumericFilterOperation.LESS_THAN_OR_EQUAL   },
+  { label: '>',  value: GANumericFilterOperation.GREATER_THAN          },
+  { label: '≥',  value: GANumericFilterOperation.GREATER_THAN_OR_EQUAL },
+];
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function exprType(expr: GAFilterExpression): string {
+  if (expr.andGroup)                    { return 'andGroup'; }
+  if (expr.orGroup)                     { return 'orGroup'; }
+  if (expr.notExpression !== undefined) { return 'notExpression'; }
+  if (expr.filter)                      { return 'filter'; }
+  return 'none';
+}
+
+function makeDefaultFilter(): GAFilter {
+  return {
+    fieldName: '',
+    filterType: GADimensionFilterType.STRING,
+    stringFilter: { matchType: GAStringFilterMatchType.EXACT, value: '', caseSensitive: false },
+  };
+}
+
+function makeDefaultExpr(): GAFilterExpression {
+  return { filter: makeDefaultFilter() };
+}
+
+function numericValueStr(v?: GANumericValue): string {
+  if (!v) { return ''; }
+  // int64Value is a string like "0", "123" — non-empty means it was explicitly set
+  if (v.int64Value != null && v.int64Value !== '') { return v.int64Value; }
+  if (v.doubleValue != null && v.doubleValue !== 0) { return String(v.doubleValue); }
+  return '';
+}
+
+function strToNumericValue(s: string): GANumericValue {
+  const trimmed = s.trim();
+  if (trimmed === '') { return {}; }
+  const n = Number(trimmed);
+  if (Number.isInteger(n)) { return { int64Value: trimmed }; }
+  return { doubleValue: isNaN(n) ? 0 : n };
+}
+
+// ─── styles ───────────────────────────────────────────────────────────────────
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const borderColors = [
+    theme.colors.primary.main,
+    theme.colors.warning.main,
+    theme.colors.success.main,
   ];
 
-  const handleExpressionTypeChange = (option: SelectableValue<string>) => {
-    let newExpression: GAFilterExpression;
-    switch (option.value) {
-      case 'none':
-        newExpression = {};
-        break;
-      case 'andGroup':
-      case 'orGroup':
-        newExpression = { [option.value]: { expressions: [] } };
-        break;
-      case 'notExpression':
-        newExpression = { notExpression: {} };
-        break;
-      case 'filter':
-        newExpression = { 
-          filter: { 
-            fieldName: '', 
-            filterType: GADimensionFilterType.STRING,
-            stringFilter: { matchType: GAStringFilterMatchType.EXACT, value: '', caseSensitive: false }
-          } 
-        };
-        break;
-      default:
-        return;
-    }
-    onChange(newExpression);
+  return {
+    row: css`
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: ${theme.spacing(0.5)};
+      min-height: ${theme.spacing(4)};
+    `,
+    group: (depth: number) => css`
+      border-left: 3px solid ${borderColors[depth % borderColors.length]};
+      padding-left: ${theme.spacing(1.5)};
+      margin-top: ${theme.spacing(0.5)};
+      display: flex;
+      flex-direction: column;
+      gap: ${theme.spacing(0.5)};
+    `,
+    groupHeader: css`
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: ${theme.spacing(0.5)};
+    `,
+    groupLabel: css`
+      color: ${theme.colors.text.secondary};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      padding: 0 ${theme.spacing(0.5)};
+      align-self: center;
+    `,
+    emptyLabel: css`
+      color: ${theme.colors.text.disabled};
+      font-style: italic;
+      font-size: ${theme.typography.bodySmall.fontSize};
+      align-self: center;
+      padding: 0 ${theme.spacing(0.5)};
+    `,
+    betweenSep: css`
+      color: ${theme.colors.text.secondary};
+      align-self: center;
+      padding: 0 ${theme.spacing(0.25)};
+    `,
+    tagInput: css`
+      flex: 1;
+      min-width: 160px;
+    `,
+    caseLabel: css`
+      color: ${theme.colors.text.secondary};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      align-self: center;
+      white-space: nowrap;
+    `,
   };
+};
 
-  const renderExpressionContent = () => {
-    if (Object.keys(expression).length === 0) {
-      return <div>No filter set</div>;
-    } else if (expression.andGroup) {
-      return renderExpressionList(expression.andGroup, 'andGroup');
-    } else if (expression.orGroup) {
-      return renderExpressionList(expression.orGroup, 'orGroup');
-    } else if (expression.notExpression) {
-      return renderNotExpression();
-    } else if (expression.filter) {
-      return renderFilter();
-    }
-    return null;
-  };
+// ─── leaf filter editors ──────────────────────────────────────────────────────
 
-  const renderExpressionList = (list: GAFilterExpressionList, type: 'andGroup' | 'orGroup') => {
-    return (
-      <VerticalGroup>
-        {list.expressions.map((expr, index) => (
-          <HorizontalGroup key={index}>
-            <GAFilterExpressionComponent
-              expression={expr}
-              selectedDimensions={selectedDimensions}
-              onChange={(newExpr) => {
-                const newList = { ...list, expressions: [...list.expressions] };
-                newList.expressions[index] = newExpr;
-                onChange({ [type]: newList });
-              }}
-              onDelete={() => {
-                const newList = { ...list, expressions: [...list.expressions] };
-                newList.expressions.splice(index, 1);
-                onChange({ [type]: newList });
-              }}
-            />
-          </HorizontalGroup>
-        ))}
-        <HorizontalGroup>
-          <Button
-            onClick={() => {
-              const newList = { ...list, expressions: [...list.expressions, {}] };
-              onChange({ [type]: newList });
-            }}
-          >
-            Add Expression
-          </Button>
-        </HorizontalGroup>
-      </VerticalGroup>
-    );
-  };
+interface StringEditorProps {
+  filter: GAStringFilter;
+  onChange: (f: GAStringFilter) => void;
+  styles: ReturnType<typeof getStyles>;
+}
+const StringEditor: React.FC<StringEditorProps> = ({ filter, onChange, styles }) => (
+  <>
+    <Select<GAStringFilterMatchType>
+      options={STRING_MATCH_OPTIONS}
+      value={filter.matchType}
+      onChange={(o) => onChange({ ...filter, matchType: o.value! })}
+      width={16}
+      menuPlacement="bottom"
+    />
+    <Input
+      value={filter.value}
+      onChange={(e) => onChange({ ...filter, value: e.currentTarget.value })}
+      placeholder="value or $variable"
+      width={20}
+    />
+    <span className={styles.caseLabel}>Aa</span>
+    <InlineSwitch
+      value={filter.caseSensitive}
+      onChange={(e) => onChange({ ...filter, caseSensitive: e.currentTarget.checked })}
+      showLabel={false}
+      title="Case sensitive"
+    />
+  </>
+);
 
-  const renderNotExpression = () => {
-    return (
-      <GAFilterExpressionComponent
-        expression={expression.notExpression!}
-        selectedDimensions={selectedDimensions}
-        onChange={(newExpr) => onChange({ notExpression: newExpr })}
-        onDelete={() => onChange({})}
+interface InListEditorProps {
+  filter: GAInListFilter;
+  onChange: (f: GAInListFilter) => void;
+  styles: ReturnType<typeof getStyles>;
+}
+const InListEditor: React.FC<InListEditorProps> = ({ filter, onChange, styles }) => (
+  <>
+    <div className={styles.tagInput}>
+      <TagsInput
+        tags={filter.values}
+        onChange={(tags) => onChange({ ...filter, values: tags })}
+        placeholder="Add value or $variable, press Enter"
+        addOnBlur
       />
-    );
+    </div>
+    <span className={styles.caseLabel}>Aa</span>
+    <InlineSwitch
+      value={filter.caseSensitive}
+      onChange={(e) => onChange({ ...filter, caseSensitive: e.currentTarget.checked })}
+      showLabel={false}
+      title="Case sensitive"
+    />
+  </>
+);
+
+interface NumericEditorProps {
+  filter: GANumericFilter;
+  onChange: (f: GANumericFilter) => void;
+}
+const NumericEditor: React.FC<NumericEditorProps> = ({ filter, onChange }) => (
+  <>
+    <Select<GANumericFilterOperation>
+      options={NUMERIC_OP_OPTIONS}
+      value={filter.operation ?? GANumericFilterOperation.EQUAL}
+      onChange={(o) => onChange({ ...filter, operation: o.value! })}
+      width={8}
+      menuPlacement="bottom"
+    />
+    <Input
+      value={numericValueStr(filter.value)}
+      onChange={(e) => onChange({ ...filter, value: strToNumericValue(e.currentTarget.value) })}
+      placeholder="number"
+      width={14}
+      type="number"
+    />
+  </>
+);
+
+interface BetweenEditorProps {
+  filter: GABetweenFilter;
+  onChange: (f: GABetweenFilter) => void;
+  styles: ReturnType<typeof getStyles>;
+}
+const BetweenEditor: React.FC<BetweenEditorProps> = ({ filter, onChange, styles }) => (
+  <>
+    <Input
+      value={numericValueStr(filter.fromValue)}
+      onChange={(e) => onChange({ ...filter, fromValue: strToNumericValue(e.currentTarget.value) })}
+      placeholder="from"
+      width={10}
+      type="number"
+    />
+    <span className={styles.betweenSep}>–</span>
+    <Input
+      value={numericValueStr(filter.toValue)}
+      onChange={(e) => onChange({ ...filter, toValue: strToNumericValue(e.currentTarget.value) })}
+      placeholder="to"
+      width={10}
+      type="number"
+    />
+  </>
+);
+
+// ─── single leaf filter row ───────────────────────────────────────────────────
+
+interface LeafFilterProps {
+  filter: GAFilter;
+  onChange: (f: GAFilter) => void;
+  loadFields: LoadFieldsFn;
+  styles: ReturnType<typeof getStyles>;
+}
+
+const LeafFilterEditor: React.FC<LeafFilterProps> = ({ filter, onChange, loadFields, styles }) => {
+  const handleTypeChange = (type: GADimensionFilterType) => {
+    const base: GAFilter = { fieldName: filter.fieldName, filterType: type };
+    switch (type) {
+      case GADimensionFilterType.STRING:
+        return onChange({ ...base, stringFilter: { matchType: GAStringFilterMatchType.EXACT, value: '', caseSensitive: false } });
+      case GADimensionFilterType.IN_LIST:
+        return onChange({ ...base, inListFilter: { values: [], caseSensitive: false } });
+      case GADimensionFilterType.NUMERIC:
+        return onChange({ ...base, numericFilter: { operation: GANumericFilterOperation.EQUAL, value: {} } });
+      case GADimensionFilterType.BETWEEN:
+        return onChange({ ...base, betweenFilter: { fromValue: {}, toValue: {} } });
+      case GADimensionFilterType.EMPTY:
+        return onChange({ ...base, emptyFilter: {} });
+    }
   };
 
-  const renderFilter = () => {
-    const filter = expression.filter || { fieldName: '', filterType: GADimensionFilterType.STRING };
-
-    const filterTypes: Array<SelectableValue<string>> = [
-      { label: 'String', value: 'STRING' },
-      { label: 'List', value: 'IN_LIST' },
-    ];
-
-    const handleFilterTypeChange = (option: SelectableValue<string>) => {
-      let newFilter: GAFilter = {
-        ...filter,
-        filterType: option.value as GADimensionFilterType,
-      };
-
-      // Set initial values based on filter type
-      switch (option.value) {
-        case GADimensionFilterType.STRING:
-          newFilter.stringFilter = { matchType: GAStringFilterMatchType.EXACT, value: '', caseSensitive: false };
-          newFilter.inListFilter = undefined;
-          break;
-        case GADimensionFilterType.IN_LIST:
-          newFilter.inListFilter = { values: [], caseSensitive: false };
-          newFilter.stringFilter = undefined;
-          break;
-      }
-
-      onChange({ filter: newFilter });
-    };
-
-    const renderFilterContent = () => {
-      switch (filter.filterType) {
-        case GADimensionFilterType.STRING:
-          return renderStringFilter(filter.stringFilter!);
-        case GADimensionFilterType.IN_LIST:
-          return renderInListFilter(filter.inListFilter!);
-        default:
-          return null;
-      }
-    };
-
-    return (
-      <VerticalGroup>
-        <Select
-          options={selectedDimensions}
-          value={filter.fieldName}
-          onChange={(option) => onChange({ filter: { ...filter, fieldName: option.value! } })}
-          placeholder="Select field"
-        />
-        <Select
-          options={filterTypes}
-          value={filter.filterType}
-          onChange={handleFilterTypeChange}
-        />
-        {renderFilterContent()}
-      </VerticalGroup>
-    );
-  };
-
-  const renderStringFilter = (stringFilter: GAStringFilter) => {
-    const matchTypes = Object.values(GAStringFilterMatchType).map(value => ({ label: value, value }));
-
-    return (
-      <VerticalGroup>
-        <Select
-          options={matchTypes}
-          value={stringFilter.matchType}
-          onChange={(option) => onChange({ filter: { ...expression.filter!, stringFilter: { ...stringFilter, matchType: option.value! } } })}
-        />
-        <Input
-          value={stringFilter.value}
-          onChange={(e) => onChange({ filter: { ...expression.filter!, stringFilter: { ...stringFilter, value: e.currentTarget.value } } })}
-          placeholder="Value"
-        />
-        <RadioButtonGroup
-          options={[
-            { label: 'Case sensitive', value: true },
-            { label: 'Case insensitive', value: false },
-          ]}
-          value={stringFilter.caseSensitive}
-          onChange={(value) => onChange({ filter: { ...expression.filter!, stringFilter: { ...stringFilter, caseSensitive: value } } })}
-        />
-      </VerticalGroup>
-    );
-  };
-
-  const renderInListFilter = (inListFilter: GAInListFilter = { values: [], caseSensitive: false }) => {
-    return (
-      <VerticalGroup>
-        <Input
-          value={inListFilter.values.join(', ')}
-          onChange={(e) => onChange({ filter: { ...expression.filter!, inListFilter: { ...inListFilter, values: e.currentTarget.value.split(',').map(v => v.trim()) } } })}
-          placeholder="Values (comma-separated)"
-        />
-        <RadioButtonGroup
-          options={[
-            { label: 'Case sensitive', value: true },
-            { label: 'Case insensitive', value: false },
-          ]}
-          value={inListFilter.caseSensitive}
-          onChange={(value) => onChange({ filter: { ...expression.filter!, inListFilter: { ...inListFilter, caseSensitive: value } } })}
-        />
-      </VerticalGroup>
-    );
+  const renderParams = () => {
+    switch (filter.filterType) {
+      case GADimensionFilterType.STRING:
+        return (
+          <StringEditor
+            filter={filter.stringFilter ?? { matchType: GAStringFilterMatchType.EXACT, value: '', caseSensitive: false }}
+            onChange={(f) => onChange({ ...filter, stringFilter: f })}
+            styles={styles}
+          />
+        );
+      case GADimensionFilterType.IN_LIST:
+        return (
+          <InListEditor
+            filter={filter.inListFilter ?? { values: [], caseSensitive: false }}
+            onChange={(f) => onChange({ ...filter, inListFilter: f })}
+            styles={styles}
+          />
+        );
+      case GADimensionFilterType.NUMERIC:
+        return (
+          <NumericEditor
+            filter={filter.numericFilter ?? { operation: GANumericFilterOperation.EQUAL, value: {} }}
+            onChange={(f) => onChange({ ...filter, numericFilter: f })}
+          />
+        );
+      case GADimensionFilterType.BETWEEN:
+        return (
+          <BetweenEditor
+            filter={filter.betweenFilter ?? { fromValue: {}, toValue: {} }}
+            onChange={(f) => onChange({ ...filter, betweenFilter: f })}
+            styles={styles}
+          />
+        );
+      case GADimensionFilterType.EMPTY:
+        return <span className={styles.emptyLabel}>is empty / not set</span>;
+      default:
+        return null;
+    }
   };
 
   return (
-    <FieldSet>
-      <HorizontalGroup>
-        <Select
-          options={expressionTypes}
-          value={Object.keys(expression).length === 0 ? 'none' : Object.keys(expression)[0]}
-          onChange={handleExpressionTypeChange}
-        />
-        {renderExpressionContent()}
-        {onDelete && (
-          <Button variant="destructive" onClick={onDelete}>
-            Delete
-          </Button>
-        )}
-      </HorizontalGroup>
-    </FieldSet>
+    <>
+      <AsyncSelect
+        loadOptions={loadFields}
+        value={filter.fieldName ? { label: filter.fieldName, value: filter.fieldName } : null}
+        onChange={(o) => onChange({ ...filter, fieldName: o?.value ?? '' })}
+        placeholder="field name"
+        allowCustomValue
+        width={22}
+        defaultOptions
+        menuPlacement="bottom"
+        isClearable
+      />
+      <Select<GADimensionFilterType>
+        options={FILTER_TYPE_OPTIONS}
+        value={filter.filterType}
+        onChange={(o) => handleTypeChange(o.value!)}
+        width={12}
+        menuPlacement="bottom"
+      />
+      {renderParams()}
+    </>
   );
+};
+
+// ─── main recursive component ─────────────────────────────────────────────────
+
+export const GAFilterExpressionComponent: React.FC<GAFilterExpressionComponentProps> = ({
+  expression,
+  onChange,
+  onDelete,
+  loadFields,
+  depth = 0,
+}) => {
+  const styles = useStyles2(getStyles);
+  const currentType = exprType(expression);
+
+  const handleTypeChange = (newType: string) => {
+    switch (newType) {
+      case 'none':
+        return onChange({});
+      case 'filter':
+        return onChange(makeDefaultExpr());
+      case 'andGroup':
+        return onChange({ andGroup: { expressions: [makeDefaultExpr()] } });
+      case 'orGroup':
+        return onChange({ orGroup: { expressions: [makeDefaultExpr()] } });
+      case 'notExpression':
+        return onChange({ notExpression: makeDefaultExpr() });
+    }
+  };
+
+  const typeSelector = (
+    <Select
+      options={EXPR_TYPE_OPTIONS}
+      value={currentType}
+      onChange={(o) => handleTypeChange(o.value!)}
+      width={14}
+      menuPlacement="bottom"
+    />
+  );
+
+  // ── none ──
+  if (currentType === 'none') {
+    return (
+      <div className={styles.row}>
+        {typeSelector}
+        {onDelete && (
+          <IconButton name="times" tooltip="Remove" size="sm" variant="destructive" onClick={onDelete} />
+        )}
+      </div>
+    );
+  }
+
+  // ── single filter ──
+  if (currentType === 'filter') {
+    const filter = expression.filter!;
+    return (
+      <div className={styles.row}>
+        {typeSelector}
+        <LeafFilterEditor
+          filter={filter}
+          onChange={(f) => onChange({ filter: f })}
+          loadFields={loadFields}
+          styles={styles}
+        />
+        {onDelete && (
+          <IconButton name="times" tooltip="Remove" size="sm" variant="destructive" onClick={onDelete} />
+        )}
+      </div>
+    );
+  }
+
+  // ── AND / OR group ──
+  if (currentType === 'andGroup' || currentType === 'orGroup') {
+    const list: GAFilterExpressionList = (expression as any)[currentType];
+
+    const addChild = () => {
+      const newList = { expressions: [...list.expressions, makeDefaultExpr()] };
+      onChange({ [currentType]: newList });
+    };
+
+    const updateChild = (index: number, child: GAFilterExpression) => {
+      const expressions = [...list.expressions];
+      expressions[index] = child;
+      onChange({ [currentType]: { expressions } });
+    };
+
+    const deleteChild = (index: number) => {
+      const expressions = list.expressions.filter((_, i) => i !== index);
+      onChange({ [currentType]: { expressions } });
+    };
+
+    return (
+      <>
+        <div className={styles.groupHeader}>
+          {typeSelector}
+          <IconButton name="plus" tooltip="Add expression" size="sm" onClick={addChild} />
+          {onDelete && (
+            <IconButton name="times" tooltip="Remove group" size="sm" variant="destructive" onClick={onDelete} />
+          )}
+        </div>
+        <div className={styles.group(depth)}>
+          {list.expressions.map((child, i) => (
+            <GAFilterExpressionComponent
+              key={i}
+              expression={child}
+              onChange={(c) => updateChild(i, c)}
+              onDelete={() => deleteChild(i)}
+              loadFields={loadFields}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  // ── NOT ──
+  if (currentType === 'notExpression') {
+    return (
+      <>
+        <div className={styles.groupHeader}>
+          {typeSelector}
+          {onDelete && (
+            <IconButton name="times" tooltip="Remove" size="sm" variant="destructive" onClick={onDelete} />
+          )}
+        </div>
+        <div className={styles.group(depth)}>
+          <GAFilterExpressionComponent
+            expression={expression.notExpression!}
+            onChange={(child) => onChange({ notExpression: child })}
+            loadFields={loadFields}
+            depth={depth + 1}
+          />
+        </div>
+      </>
+    );
+  }
+
+  return null;
 };

--- a/src/Filter.tsx
+++ b/src/Filter.tsx
@@ -406,7 +406,7 @@ export const GAFilterExpressionComponent: React.FC<GAFilterExpressionComponentPr
   // ── none ──
   if (currentType === 'none') {
     return (
-      <div className={styles.row}>
+      <div className={styles.row} data-testid="filter-expression">
         {typeSelector}
         {onDelete && (
           <IconButton name="times" tooltip="Remove" size="sm" variant="destructive" onClick={onDelete} />
@@ -419,7 +419,7 @@ export const GAFilterExpressionComponent: React.FC<GAFilterExpressionComponentPr
   if (currentType === 'filter') {
     const filter = expression.filter!;
     return (
-      <div className={styles.row}>
+      <div className={styles.row} data-testid="filter-expression">
         {typeSelector}
         <LeafFilterEditor
           filter={filter}
@@ -455,7 +455,7 @@ export const GAFilterExpressionComponent: React.FC<GAFilterExpressionComponentPr
     };
 
     return (
-      <>
+      <div data-testid="filter-expression">
         <div className={styles.groupHeader}>
           {typeSelector}
           <IconButton name="plus" tooltip="Add expression" size="sm" onClick={addChild} />
@@ -475,14 +475,14 @@ export const GAFilterExpressionComponent: React.FC<GAFilterExpressionComponentPr
             />
           ))}
         </div>
-      </>
+      </div>
     );
   }
 
   // ── NOT ──
   if (currentType === 'notExpression') {
     return (
-      <>
+      <div data-testid="filter-expression">
         <div className={styles.groupHeader}>
           {typeSelector}
           {onDelete && (
@@ -497,7 +497,7 @@ export const GAFilterExpressionComponent: React.FC<GAFilterExpressionComponentPr
             depth={depth + 1}
           />
         </div>
-      </>
+      </div>
     );
   }
 

--- a/src/QueryEditorGA4.tsx
+++ b/src/QueryEditorGA4.tsx
@@ -323,7 +323,7 @@ export class QueryEditorGA4 extends PureComponent<Props> {
               loadFields={((q: string) => {
                 const loadDimFields: LoadFieldsFn = mode === 'realtime'
                   ? (s) => datasource.getRealtimeDimensions(s, null, parsedWebPropertyId)
-                  : (s) => datasource.getDimensionsExcludeTimeDimensions(s, parsedWebPropertyId);
+                  : (s) => datasource.getDimensions(s, null, parsedWebPropertyId);
                 return loadDimFields(q);
               }) as LoadFieldsFn}
             />

--- a/src/QueryEditorGA4.tsx
+++ b/src/QueryEditorGA4.tsx
@@ -15,6 +15,7 @@ import { GAFilterExpressionComponent } from 'Filter';
 import _ from 'lodash';
 import React, { PureComponent } from 'react';
 import { GADataSourceOptions, GAFilterExpression, GAQuery } from 'types';
+import type { LoadFieldsFn } from 'Filter';
 type Props = QueryEditorProps<DataSource, GAQuery, GADataSourceOptions>;
 
 const defaultCacheDuration = 300;
@@ -118,6 +119,12 @@ export class QueryEditorGA4 extends PureComponent<Props> {
   onFiltersExpressionChange = (newFilter: GAFilterExpression) => {
     const { query, onChange } = this.props;
     onChange({ ...query, dimensionFilter: newFilter });
+    this.willRunQuery();
+  };
+
+  onMetricFilterChange = (newFilter: GAFilterExpression) => {
+    const { query, onChange } = this.props;
+    onChange({ ...query, metricFilter: newFilter });
     this.willRunQuery();
   };
 
@@ -306,19 +313,37 @@ export class QueryEditorGA4 extends PureComponent<Props> {
           <div className="gf-form">
             <InlineFormLabel
               className="query-keyword"
-              tooltip={
-                <>
-                  Currently, only <code>or groups</code> are supported.
-                </>
-              }
+              tooltip="Filter rows by dimension values (applied before aggregation)"
             >
-              DimensionFilter
+              Dimension Filter
             </InlineFormLabel>
-            <GAFilterExpressionComponent 
-              expression={query.dimensionFilter} 
+            <GAFilterExpressionComponent
+              expression={query.dimensionFilter}
               onChange={this.onFiltersExpressionChange}
-              selectedDimensions={selectedDimensions}
-              onDelete={undefined}
+              loadFields={((q: string) => {
+                const loadDimFields: LoadFieldsFn = mode === 'realtime'
+                  ? (s) => datasource.getRealtimeDimensions(s, null, parsedWebPropertyId)
+                  : (s) => datasource.getDimensionsExcludeTimeDimensions(s, parsedWebPropertyId);
+                return loadDimFields(q);
+              }) as LoadFieldsFn}
+            />
+          </div>
+          <div className="gf-form">
+            <InlineFormLabel
+              className="query-keyword"
+              tooltip="Filter rows by metric values — applied after aggregation (SQL HAVING equivalent)"
+            >
+              Metric Filter
+            </InlineFormLabel>
+            <GAFilterExpressionComponent
+              expression={query.metricFilter ?? {}}
+              onChange={this.onMetricFilterChange}
+              loadFields={((q: string) => {
+                const loadMetFields: LoadFieldsFn = mode === 'realtime'
+                  ? (s) => datasource.getRealtimeMetrics(s, parsedWebPropertyId)
+                  : (s) => datasource.getMetrics(s, parsedWebPropertyId);
+                return loadMetFields(q);
+              }) as LoadFieldsFn}
             />
           </div>
           <div className="gf-form">

--- a/src/interpolation.test.ts
+++ b/src/interpolation.test.ts
@@ -1,7 +1,7 @@
 import { ScopedVars } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 import { expandVariableToArray, interpolateFilterExpression } from './interpolation';
-import { GADimensionFilterType, GAFilterExpression, GAStringFilterMatchType } from './types';
+import { GADimensionFilterType, GAFilterExpression, GANumericFilterOperation, GAStringFilterMatchType } from './types';
 
 // Minimal TemplateSrv stub that mimics Grafana's behavior for unit tests:
 // - $var / ${var} is looked up in the map.
@@ -191,5 +191,49 @@ describe('interpolateFilterExpression', () => {
     interpolateFilterExpression(srv, expr, {});
     expect(expr.andGroup!.expressions[0].filter!.inListFilter!.values).toEqual(['1', '2']);
     expect(expr.andGroup!.expressions[1].filter!.inListFilter!.values).toEqual(['3', '4']);
+  });
+
+  it('does not touch numericFilter (no string interpolation needed)', () => {
+    const srv = makeTemplateSrv({ n: '999' });
+    const expr: GAFilterExpression = {
+      filter: {
+        fieldName: 'sessions',
+        filterType: GADimensionFilterType.NUMERIC,
+        numericFilter: {
+          operation: GANumericFilterOperation.GREATER_THAN,
+          value: { int64Value: '100' },
+        },
+      },
+    };
+    interpolateFilterExpression(srv, expr, {});
+    // Numeric values are set via the UI as literal numbers, not interpolated.
+    expect(expr.filter!.numericFilter!.value.int64Value).toBe('100');
+    expect(expr.filter!.numericFilter!.operation).toBe(GANumericFilterOperation.GREATER_THAN);
+  });
+
+  it('does not crash on betweenFilter', () => {
+    const srv = makeTemplateSrv({});
+    const expr: GAFilterExpression = {
+      filter: {
+        fieldName: 'sessions',
+        filterType: GADimensionFilterType.BETWEEN,
+        betweenFilter: { fromValue: { int64Value: '10' }, toValue: { int64Value: '100' } },
+      },
+    };
+    expect(() => interpolateFilterExpression(srv, expr, {})).not.toThrow();
+    expect(expr.filter!.betweenFilter!.fromValue.int64Value).toBe('10');
+    expect(expr.filter!.betweenFilter!.toValue.int64Value).toBe('100');
+  });
+
+  it('does not crash on emptyFilter', () => {
+    const srv = makeTemplateSrv({});
+    const expr: GAFilterExpression = {
+      filter: {
+        fieldName: 'campaignName',
+        filterType: GADimensionFilterType.EMPTY,
+        emptyFilter: {},
+      },
+    };
+    expect(() => interpolateFilterExpression(srv, expr, {})).not.toThrow();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,9 +22,10 @@ export interface GAQuery extends DataQuery {
   filtersExpression: string;
   mode: string;
   dimensionFilter: GAFilterExpression;
+  metricFilter?: GAFilterExpression;
   serviceLevel: string;
-  // metricFilter: Array<GAFilter>;
 }
+
 // mapping on google-key.json
 export interface JWT {
   private_key: any;
@@ -33,9 +34,7 @@ export interface JWT {
   project_id: any;
 }
 
-export const defaultQuery: Partial<GAQuery> = {
-  // constant: 6.5,
-};
+export const defaultQuery: Partial<GAQuery> = {};
 
 /**
  * These are options configured for each DataSource instance.
@@ -91,28 +90,27 @@ export interface ProfileSummary {
   Type: string
 }
 
-// https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression?hl=ko#Filter
+// https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression
 
 export interface GAFilterExpression {
-  andGroup?: GAFilterExpressionList
-  orGroup?: GAFilterExpressionList
-  notExpression?: GAFilterExpression
-  filter?: GAFilter
+  andGroup?: GAFilterExpressionList;
+  orGroup?: GAFilterExpressionList;
+  notExpression?: GAFilterExpression;
+  filter?: GAFilter;
 }
 
 export interface GAFilterExpressionList {
-  expressions: GAFilterExpression[]
+  expressions: GAFilterExpression[];
 }
 
 export interface GAFilter {
   fieldName: string;
-  
-  // filterType: GAMetricFilterType | GADimensionFilterType | undefined;
   filterType: GADimensionFilterType;
   stringFilter?: GAStringFilter;
   inListFilter?: GAInListFilter;
-  numberFilter?: GANumbericFilter;
+  numericFilter?: GANumericFilter;
   betweenFilter?: GABetweenFilter;
+  emptyFilter?: GAEmptyFilter;
 }
 
 export interface GAStringFilter {
@@ -126,48 +124,54 @@ export interface GAInListFilter {
   caseSensitive: boolean;
 }
 
-export interface GANumbericFilter {
-  operation: GANumbericFilterOperation;
-  value: GANumbericValue;
-  caseSensitive: boolean;
+export interface GANumericFilter {
+  operation: GANumericFilterOperation;
+  value: GANumericValue;
 }
 
 export interface GABetweenFilter {
-  fromValue: GANumbericValue;
-  toValue: GANumbericValue;
+  fromValue: GANumericValue;
+  toValue: GANumericValue;
 }
 
-export interface GANumbericValue {
-  int64Value: string;
-  doubleValue: number;
+// int64Value serialises as a JSON string per the GA4 API spec
+export interface GANumericValue {
+  int64Value?: string;
+  doubleValue?: number;
 }
+
+export interface GAEmptyFilter {}
 
 export enum GADimensionFilterType {
-  STRING = "STRING",
-  IN_LIST = "IN_LIST"
+  STRING  = 'STRING',
+  IN_LIST = 'IN_LIST',
+  NUMERIC = 'NUMERIC',
+  BETWEEN = 'BETWEEN',
+  EMPTY   = 'EMPTY',
 }
-
-export enum GAMetricFilterType {
-  NUMBERIC,
-  BETWEEN
-}
-
 
 export enum GAStringFilterMatchType {
-  MATCH_TYPE_UNSPECIFIED = "MATCH_TYPE_UNSPECIFIED",
-  EXACT = "EXACT",
-  BEGINS_WITH = "BEGINS_WITH",
-  ENDS_WITH = "ENDS_WITH",
-  CONTAINS = "CONTAINS",
-  FULL_REGEXP = "FULL_REGEXP",
-  PARTIAL_REGEXP = "PARTIAL_REGEXP"
+  EXACT           = 'EXACT',
+  BEGINS_WITH     = 'BEGINS_WITH',
+  ENDS_WITH       = 'ENDS_WITH',
+  CONTAINS        = 'CONTAINS',
+  FULL_REGEXP     = 'FULL_REGEXP',
+  PARTIAL_REGEXP  = 'PARTIAL_REGEXP',
 }
 
-export enum GANumbericFilterOperation {
-  OPERATION_UNSPECIFIED,
-  EQUAL,
-  LESS_THAN,
-  LESS_THAN_OR_EQUAL,
-  GREATER_THAN,
-  GREATER_THAN_OR_EQUAL,
+export enum GANumericFilterOperation {
+  OPERATION_UNSPECIFIED   = 'OPERATION_UNSPECIFIED',
+  EQUAL                   = 'EQUAL',
+  LESS_THAN               = 'LESS_THAN',
+  LESS_THAN_OR_EQUAL      = 'LESS_THAN_OR_EQUAL',
+  GREATER_THAN            = 'GREATER_THAN',
+  GREATER_THAN_OR_EQUAL   = 'GREATER_THAN_OR_EQUAL',
 }
+
+// Legacy aliases kept for any persisted dashboard JSON that might reference them
+/** @deprecated use GANumericFilter */
+export type GANumbericFilter = GANumericFilter;
+/** @deprecated use GANumericFilterOperation */
+export type GANumbericFilterOperation = GANumericFilterOperation;
+/** @deprecated use GANumericValue */
+export type GANumbericValue = GANumericValue;

--- a/tests/features/filterUI.spec.ts
+++ b/tests/features/filterUI.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@grafana/plugin-e2e';
+import { dismissWhatsNewModal } from '../utils';
 
 // Tests for the new Filter UI component (AND/OR/NOT/FILTER tree editor)
 // These tests verify UI interactions without requiring real GA credentials.
@@ -15,6 +16,7 @@ test.describe('DimensionFilter UI', () => {
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await explorePage.datasource.set(ds.name);
+    await dismissWhatsNewModal(page);
     await waitForPageSettle(page);
 
     const queryRow = explorePage.getQueryEditorRow('A');
@@ -34,6 +36,7 @@ test.describe('DimensionFilter UI', () => {
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await explorePage.datasource.set(ds.name);
+    await dismissWhatsNewModal(page);
     await waitForPageSettle(page);
 
     const queryRow = explorePage.getQueryEditorRow('A');
@@ -56,6 +59,7 @@ test.describe('DimensionFilter UI', () => {
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await explorePage.datasource.set(ds.name);
+    await dismissWhatsNewModal(page);
     await waitForPageSettle(page);
 
     const queryRow = explorePage.getQueryEditorRow('A');
@@ -84,6 +88,7 @@ test.describe('DimensionFilter UI', () => {
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await explorePage.datasource.set(ds.name);
+    await dismissWhatsNewModal(page);
     await waitForPageSettle(page);
 
     const queryRow = explorePage.getQueryEditorRow('A');
@@ -103,6 +108,7 @@ test.describe('DimensionFilter UI', () => {
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await explorePage.datasource.set(ds.name);
+    await dismissWhatsNewModal(page);
     await waitForPageSettle(page);
 
     const queryRow = explorePage.getQueryEditorRow('A');
@@ -124,6 +130,7 @@ test.describe('DimensionFilter UI', () => {
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await explorePage.datasource.set(ds.name);
+    await dismissWhatsNewModal(page);
     await waitForPageSettle(page);
 
     const queryRow = explorePage.getQueryEditorRow('A');
@@ -156,6 +163,7 @@ test.describe('DimensionFilter UI', () => {
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await explorePage.datasource.set(ds.name);
+    await dismissWhatsNewModal(page);
     await waitForPageSettle(page);
 
     const queryRow = explorePage.getQueryEditorRow('A');

--- a/tests/features/filterUI.spec.ts
+++ b/tests/features/filterUI.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+// Tests for the new Filter UI component (AND/OR/NOT/FILTER tree editor)
+// These tests verify UI interactions without requiring real GA credentials.
+
+const waitForPageSettle = async (page: import('@playwright/test').Page) => {
+  await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+};
+
+test.describe('DimensionFilter UI', () => {
+  test('filter component renders with "no filter" default', async ({
+    readProvisionedDataSource,
+    explorePage,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await explorePage.datasource.set(ds.name);
+    await waitForPageSettle(page);
+
+    const queryRow = explorePage.getQueryEditorRow('A');
+
+    // The filter expression container should be present and default to 'No filter'
+    const filterExpr = queryRow.locator('[data-testid="filter-expression"]').first();
+    await expect(filterExpr).toBeVisible({ timeout: 15000 });
+
+    const noFilterOption = filterExpr.locator('[class*="singleValue"]').first();
+    await expect(noFilterOption).toContainText(/no filter/i);
+  });
+
+  test('can switch to OR group filter', async ({
+    readProvisionedDataSource,
+    explorePage,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await explorePage.datasource.set(ds.name);
+    await waitForPageSettle(page);
+
+    const queryRow = explorePage.getQueryEditorRow('A');
+    const filterExpr = queryRow.locator('[data-testid="filter-expression"]').first();
+    await expect(filterExpr).toBeVisible({ timeout: 15000 });
+
+    // Open the filter type dropdown and select OR group
+    await filterExpr.locator('[class*="grafana-select-value-container"]').first().click();
+    await expect(page.getByLabel('Select options menu')).toBeVisible();
+    await page.getByLabel('Select options menu').getByText('OR group', { exact: true }).click();
+
+    // After selecting OR group, "Add expression" icon button should appear
+    await expect(filterExpr.getByRole('button', { name: 'Add expression' })).toBeVisible();
+  });
+
+  test('can add a Filter expression inside OR group', async ({
+    readProvisionedDataSource,
+    explorePage,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await explorePage.datasource.set(ds.name);
+    await waitForPageSettle(page);
+
+    const queryRow = explorePage.getQueryEditorRow('A');
+    const filterExpr = queryRow.locator('[data-testid="filter-expression"]').first();
+    await expect(filterExpr).toBeVisible({ timeout: 15000 });
+
+    // Switch to OR group (adds one default child expression automatically)
+    await filterExpr.locator('[class*="grafana-select-value-container"]').first().click();
+    await page.getByLabel('Select options menu').getByText('OR group', { exact: true }).click();
+
+    // Add another child expression
+    await filterExpr.getByRole('button', { name: 'Add expression' }).click();
+
+    // Child expressions should appear (default type is Filter with a string filter)
+    const childExprs = filterExpr.locator('[data-testid="filter-expression"]');
+    await expect(childExprs.first()).toBeVisible();
+
+    // The value input for the string filter should be present
+    await expect(childExprs.first().getByPlaceholder('value or $variable')).toBeVisible();
+  });
+
+  test('can switch to AND group filter', async ({
+    readProvisionedDataSource,
+    explorePage,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await explorePage.datasource.set(ds.name);
+    await waitForPageSettle(page);
+
+    const queryRow = explorePage.getQueryEditorRow('A');
+    const filterExpr = queryRow.locator('[data-testid="filter-expression"]').first();
+    await expect(filterExpr).toBeVisible({ timeout: 15000 });
+
+    // Switch to AND group
+    await filterExpr.locator('[class*="grafana-select-value-container"]').first().click();
+    await page.getByLabel('Select options menu').getByText('AND group', { exact: true }).click();
+    await expect(filterExpr.getByRole('button', { name: 'Add expression' })).toBeVisible();
+  });
+
+  test('can switch to NOT expression filter', async ({
+    readProvisionedDataSource,
+    explorePage,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await explorePage.datasource.set(ds.name);
+    await waitForPageSettle(page);
+
+    const queryRow = explorePage.getQueryEditorRow('A');
+    const filterExpr = queryRow.locator('[data-testid="filter-expression"]').first();
+    await expect(filterExpr).toBeVisible({ timeout: 15000 });
+
+    // Switch to NOT expression
+    await filterExpr.locator('[class*="grafana-select-value-container"]').first().click();
+    await page.getByLabel('Select options menu').getByText('NOT', { exact: true }).click();
+
+    // NOT wraps a child expression — inner filter-expression should appear
+    await expect(filterExpr.locator('[data-testid="filter-expression"]').first()).toBeVisible();
+  });
+
+  test('can add and delete filter expressions', async ({
+    readProvisionedDataSource,
+    explorePage,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await explorePage.datasource.set(ds.name);
+    await waitForPageSettle(page);
+
+    const queryRow = explorePage.getQueryEditorRow('A');
+    const filterExpr = queryRow.locator('[data-testid="filter-expression"]').first();
+    await expect(filterExpr).toBeVisible({ timeout: 15000 });
+
+    // Switch to OR group and add two more expressions (one is added automatically)
+    await filterExpr.locator('[class*="grafana-select-value-container"]').first().click();
+    await page.getByLabel('Select options menu').getByText('OR group', { exact: true }).click();
+    await filterExpr.getByRole('button', { name: 'Add expression' }).click();
+    await filterExpr.getByRole('button', { name: 'Add expression' }).click();
+
+    // Should have at least 2 child filter-expression elements
+    const childCount = await filterExpr.locator('[data-testid="filter-expression"]').count();
+    expect(childCount).toBeGreaterThanOrEqual(2);
+
+    // Delete first child via its Remove button
+    const deleteBtn = filterExpr.locator('[data-testid="filter-expression"]').first().getByRole('button', { name: 'Remove' });
+    await deleteBtn.click();
+
+    // Should now have fewer children
+    const newChildCount = await filterExpr.locator('[data-testid="filter-expression"]').count();
+    expect(newChildCount).toBeLessThan(childCount);
+  });
+
+  test('filter supports string match types', async ({
+    readProvisionedDataSource,
+    explorePage,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await explorePage.datasource.set(ds.name);
+    await waitForPageSettle(page);
+
+    const queryRow = explorePage.getQueryEditorRow('A');
+    const filterExpr = queryRow.locator('[data-testid="filter-expression"]').first();
+    await expect(filterExpr).toBeVisible({ timeout: 15000 });
+
+    // Switch to OR group and add a child expression (already a Filter type with string filter)
+    await filterExpr.locator('[class*="grafana-select-value-container"]').first().click();
+    await page.getByLabel('Select options menu').getByText('OR group', { exact: true }).click();
+
+    const childExpr = filterExpr.locator('[data-testid="filter-expression"]').first();
+    await expect(childExpr).toBeVisible();
+
+    // Match type select is the 4th select-value-container in the child:
+    // nth(0)=expr type, nth(1)=field name AsyncSelect, nth(2)=filter type, nth(3)=match type
+    const matchTypeSelect = childExpr.locator('[class*="grafana-select-value-container"]').nth(3);
+    await expect(matchTypeSelect).toContainText(/exact|contains|begins with|ends with/i);
+
+    // Switch to Contains
+    await matchTypeSelect.click();
+    await page.getByLabel('Select options menu').getByText('Contains', { exact: true }).click();
+    await expect(matchTypeSelect).toContainText(/contains/i);
+  });
+});

--- a/tests/features/migrationUI.spec.ts
+++ b/tests/features/migrationUI.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Migration UI tests: verify that old dashboard JSON files render without
+// JavaScript errors and without a "panel error" when upgrading from v0.3.1.
+// These do NOT require real GA credentials - they check that the plugin
+// handles old query formats gracefully (no crash / no unhandled JS error).
+
+const waitForPageSettle = async (page: import('@playwright/test').Page) => {
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+};
+
+const getDashboardVersions = () => {
+  const dashboardsDir = path.join(__dirname, '../../provisioning/dashboards');
+  return fs
+    .readdirSync(dashboardsDir)
+    .filter((f) => f.match(/^v\d+\.\d+\.\d+\.json$/))
+    .map((f) => f.replace('.json', ''));
+};
+
+getDashboardVersions().forEach((version) => {
+  test(`${version}: dashboard loads without JS crash`, async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    page,
+  }) => {
+    // Collect console errors
+    const jsErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        jsErrors.push(msg.text());
+      }
+    });
+
+    const dashboard = await readProvisionedDashboard({ fileName: `${version}.json` });
+    await gotoDashboardPage({ uid: dashboard.uid });
+    await waitForPageSettle(page);
+
+    // No unhandled React/JS errors from the plugin (ignore Grafana internal network errors)
+    const reactErrors = jsErrors.filter(
+      (e) =>
+        (e.includes('Uncaught') || e.includes('TypeError') || e.includes('Cannot read')) &&
+        !e.includes('Error loading recent dashboard actions') &&
+        !e.includes('Failed to fetch')
+    );
+    expect(reactErrors, `JS errors on ${version} dashboard: ${reactErrors.join(', ')}`).toHaveLength(0);
+  });
+
+  test(`${version}: panels render (no "panel plugin not found" error)`, async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    page,
+  }) => {
+    const dashboard = await readProvisionedDashboard({ fileName: `${version}.json` });
+    await gotoDashboardPage({ uid: dashboard.uid });
+    await waitForPageSettle(page);
+
+    // Plugin-not-found would show this text
+    const pluginError = page.getByText('Panel plugin not found', { exact: false });
+    await expect(pluginError).not.toBeVisible();
+
+    // Page URL should remain on the dashboard (no redirect to error page)
+    await expect(page).toHaveURL(/\/d\//i);
+  });
+});
+
+test('default dashboard loads without JS crash', async ({
+  readProvisionedDashboard,
+  gotoDashboardPage,
+  page,
+}) => {
+  const jsErrors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') jsErrors.push(msg.text());
+  });
+
+  const dashboard = await readProvisionedDashboard({ fileName: 'default.json' });
+  await gotoDashboardPage({ uid: dashboard.uid });
+  await waitForPageSettle(page);
+
+  const reactErrors = jsErrors.filter(
+    (e) =>
+      (e.includes('Uncaught') || e.includes('TypeError') || e.includes('Cannot read')) &&
+      !e.includes('Error loading recent dashboard actions') &&
+      !e.includes('Failed to fetch')
+  );
+  expect(reactErrors, `JS errors on default dashboard: ${reactErrors.join(', ')}`).toHaveLength(0);
+});

--- a/tests/features/migrationUI.spec.ts
+++ b/tests/features/migrationUI.spec.ts
@@ -72,7 +72,9 @@ test('default dashboard loads without JS crash', async ({
 }) => {
   const jsErrors: string[] = [];
   page.on('console', (msg) => {
-    if (msg.type() === 'error') jsErrors.push(msg.text());
+    if (msg.type() === 'error') {
+      jsErrors.push(msg.text());
+    }
   });
 
   const dashboard = await readProvisionedDashboard({ fileName: 'default.json' });

--- a/tests/features/upgradeSim.spec.ts
+++ b/tests/features/upgradeSim.spec.ts
@@ -21,7 +21,11 @@ test('phase1: v0.3.1 provisioned dashboards load without JS crash', async ({
   for (const version of ['v0.2.2', 'v0.2.3', 'v0.3.0']) {
     const dashboard = await readProvisionedDashboard({ fileName: `${version}.json` });
     const errors: string[] = [];
-    page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+    page.on('console', (m) => {
+      if (m.type() === 'error') {
+        errors.push(m.text());
+      }
+    });
 
     await page.goto(`http://localhost:3000/d/${dashboard.uid}`);
     await waitForPageSettle(page);
@@ -163,7 +167,11 @@ test('phase1: check v0.3.1 handles unknown filter types gracefully', async ({
   const saved = await resp.json();
 
   const errors: string[] = [];
-  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('console', (m) => {
+    if (m.type() === 'error') {
+      errors.push(m.text());
+    }
+  });
 
   await page.goto(`http://localhost:3000/d/${saved.uid}`);
   await waitForPageSettle(page);
@@ -199,7 +207,11 @@ test('phase2: v0.3.1 mutation-artifact loads after upgrade', async ({ page }) =>
   if (!fixture) { test.skip(); return; }
 
   const errors: string[] = [];
-  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('console', (m) => {
+    if (m.type() === 'error') {
+      errors.push(m.text());
+    }
+  });
 
   await page.goto(`http://localhost:3000/d/${fixture.uid}`);
   await waitForPageSettle(page);
@@ -227,7 +239,11 @@ test('phase2: forward-compat andGroup filter loads after upgrade', async ({ page
   if (!fixture) { test.skip(); return; }
 
   const errors: string[] = [];
-  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('console', (m) => {
+    if (m.type() === 'error') {
+      errors.push(m.text());
+    }
+  });
 
   await page.goto(`http://localhost:3000/d/${fixture.uid}`);
   await waitForPageSettle(page);
@@ -248,7 +264,11 @@ test('phase2: provisioned dashboards all pass after upgrade', async ({
   for (const version of ['v0.2.2', 'v0.2.3', 'v0.3.0']) {
     const dashboard = await readProvisionedDashboard({ fileName: `${version}.json` });
     const errors: string[] = [];
-    page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+    page.on('console', (m) => {
+      if (m.type() === 'error') {
+        errors.push(m.text());
+      }
+    });
 
     await page.goto(`http://localhost:3000/d/${dashboard.uid}`);
     await waitForPageSettle(page);

--- a/tests/features/upgradeSim.spec.ts
+++ b/tests/features/upgradeSim.spec.ts
@@ -1,0 +1,264 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const waitForPageSettle = async (page: import('@playwright/test').Page) => {
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+};
+
+const FIXTURES_DIR = path.join(__dirname, '../fixtures');
+
+// ─────────────────────────────────────────────────────────
+// PHASE 1  (run with v0.3.1 dist)
+// Creates representative dashboards and saves their UIDs
+// to tests/fixtures/ for phase2 to consume.
+// ─────────────────────────────────────────────────────────
+
+test('phase1: v0.3.1 provisioned dashboards load without JS crash', async ({
+  readProvisionedDashboard,
+  page,
+}) => {
+  for (const version of ['v0.2.2', 'v0.2.3', 'v0.3.0']) {
+    const dashboard = await readProvisionedDashboard({ fileName: `${version}.json` });
+    const errors: string[] = [];
+    page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+
+    await page.goto(`http://localhost:3000/d/${dashboard.uid}`);
+    await waitForPageSettle(page);
+
+    const critical = errors.filter(
+      e => (e.includes('TypeError') || e.includes('Cannot read')) &&
+           !e.includes('Failed to fetch') && !e.includes('Error loading recent')
+    );
+    expect(critical, `${version} JS errors on v0.3.1: ${critical.join('\n')}`).toHaveLength(0);
+    console.log(`✅ ${version} OK on v0.3.1`);
+  }
+});
+
+test('phase1: create mutation-artifact dashboard (simulates v0.3.1 filter mutation bug)', async ({
+  request,
+}) => {
+  const ds = await request.get('http://localhost:3000/api/datasources/uid/lcc3108_test');
+  const dsData = await ds.json();
+
+  // v0.3.1 bug: after first query run with $country variable,
+  // stringFilter.value gets mutated to the resolved value in the saved model.
+  const dashboard = {
+    dashboard: {
+      title: 'v0.3.1 Migration — Filter Mutation Artifact',
+      uid: 'v031-filter-artifact',
+      tags: ['migration-test'],
+      panels: [{
+        id: 1,
+        type: 'timeseries',
+        title: 'GA4 with orGroup filter (post-mutation state)',
+        gridPos: { h: 8, w: 12, x: 0, y: 0 },
+        datasource: { type: dsData.type, uid: dsData.uid },
+        targets: [{
+          refId: 'A',
+          version: 'v4',
+          webPropertyId: 'properties/123456789',
+          accountId: 'accounts/123',
+          metrics: ['activeUsers'],
+          timeDimension: 'date',
+          dimensions: ['country'],
+          mode: 'time series',
+          // Simulates the post-mutation state from v0.3.1:
+          // originally "$country" but got permanently overwritten to "United States"
+          dimensionFilter: {
+            orGroup: {
+              expressions: [{
+                filter: {
+                  fieldName: 'country',
+                  filterType: 'STRING',
+                  stringFilter: {
+                    matchType: 'EXACT',
+                    value: 'United States',
+                    caseSensitive: false,
+                  },
+                },
+              }],
+            },
+          },
+        }],
+      }],
+      time: { from: 'now-7d', to: 'now' },
+      schemaVersion: 36,
+    },
+    folderId: 0,
+    overwrite: true,
+  };
+
+  const resp = await request.post('http://localhost:3000/api/dashboards/db', {
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify(dashboard),
+  });
+  expect(resp.ok()).toBeTruthy();
+  const saved = await resp.json();
+
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  fs.writeFileSync(
+    path.join(FIXTURES_DIR, 'v031-artifact.json'),
+    JSON.stringify({ uid: saved.uid, url: saved.url }, null, 2)
+  );
+  console.log(`✅ Phase1 — artifact saved: uid=${saved.uid}`);
+});
+
+// Also create a dashboard with andGroup / nested filter (new in current branch)
+// to verify the reverse direction doesn't break v0.3.1 rendering.
+test('phase1: check v0.3.1 handles unknown filter types gracefully', async ({
+  request,
+  page,
+}) => {
+  // Create a dashboard with an andGroup filter (not supported in v0.3.1 UI
+  // but should still load without crashing since the backend ignores unknown fields).
+  const ds = await request.get('http://localhost:3000/api/datasources/uid/lcc3108_test');
+  const dsData = await ds.json();
+
+  const dashboard = {
+    dashboard: {
+      title: 'Forward-compat: andGroup filter on v0.3.1',
+      uid: 'v031-forward-compat',
+      tags: ['migration-test'],
+      panels: [{
+        id: 1,
+        type: 'timeseries',
+        title: 'Panel with andGroup',
+        gridPos: { h: 8, w: 12, x: 0, y: 0 },
+        datasource: { type: dsData.type, uid: dsData.uid },
+        targets: [{
+          refId: 'A',
+          version: 'v4',
+          webPropertyId: 'properties/123456789',
+          metrics: ['activeUsers'],
+          timeDimension: 'date',
+          mode: 'time series',
+          dimensionFilter: {
+            andGroup: {
+              expressions: [
+                {
+                  filter: {
+                    fieldName: 'country',
+                    filterType: 'STRING',
+                    stringFilter: { matchType: 'EXACT', value: 'United States', caseSensitive: false },
+                  },
+                },
+              ],
+            },
+          },
+        }],
+      }],
+      time: { from: 'now-7d', to: 'now' },
+      schemaVersion: 36,
+    },
+    folderId: 0,
+    overwrite: true,
+  };
+
+  const resp = await request.post('http://localhost:3000/api/dashboards/db', {
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify(dashboard),
+  });
+  expect(resp.ok()).toBeTruthy();
+  const saved = await resp.json();
+
+  const errors: string[] = [];
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+
+  await page.goto(`http://localhost:3000/d/${saved.uid}`);
+  await waitForPageSettle(page);
+
+  const critical = errors.filter(
+    e => (e.includes('TypeError') || e.includes('Cannot read')) &&
+         !e.includes('Failed to fetch') && !e.includes('Error loading recent')
+  );
+  expect(critical, `Forward-compat JS errors: ${critical.join('\n')}`).toHaveLength(0);
+  await expect(page.getByText('Panel plugin not found', { exact: false })).not.toBeVisible();
+
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  fs.writeFileSync(
+    path.join(FIXTURES_DIR, 'v031-forward-compat.json'),
+    JSON.stringify({ uid: saved.uid }, null, 2)
+  );
+  console.log(`✅ Phase1 — forward-compat dashboard OK on v0.3.1`);
+});
+
+// ─────────────────────────────────────────────────────────
+// PHASE 2  (run after swapping to current dist)
+// Loads all phase1 dashboards and verifies they work.
+// ─────────────────────────────────────────────────────────
+
+const loadFixture = (name: string) => {
+  const p = path.join(FIXTURES_DIR, name);
+  if (!fs.existsSync(p)) { return null; }
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+};
+
+test('phase2: v0.3.1 mutation-artifact loads after upgrade', async ({ page }) => {
+  const fixture = loadFixture('v031-artifact.json');
+  if (!fixture) { test.skip(); return; }
+
+  const errors: string[] = [];
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+
+  await page.goto(`http://localhost:3000/d/${fixture.uid}`);
+  await waitForPageSettle(page);
+
+  const critical = errors.filter(
+    e => (e.includes('TypeError') || e.includes('Cannot read')) &&
+         !e.includes('Failed to fetch') && !e.includes('Error loading recent')
+  );
+  expect(critical, `Upgrade JS errors:\n${critical.join('\n')}`).toHaveLength(0);
+  await expect(page.getByText('Panel plugin not found', { exact: false })).not.toBeVisible();
+  await expect(page).toHaveURL(/\/d\//);
+
+  // Verify the filter UI shows the orGroup value (not crashed/blank)
+  await page.goto(`http://localhost:3000/d/${fixture.uid}?orgId=1&editPanel=1`);
+  await waitForPageSettle(page);
+  // The filter expression should still render (current version must handle orGroup from v0.3.1)
+  const filterFieldset = page.locator('[data-testid="filter-expression"]').first();
+  await expect(filterFieldset).toBeVisible({ timeout: 15000 });
+
+  console.log('✅ Phase2 — v0.3.1 mutation artifact loads correctly after upgrade');
+});
+
+test('phase2: forward-compat andGroup filter loads after upgrade', async ({ page }) => {
+  const fixture = loadFixture('v031-forward-compat.json');
+  if (!fixture) { test.skip(); return; }
+
+  const errors: string[] = [];
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+
+  await page.goto(`http://localhost:3000/d/${fixture.uid}`);
+  await waitForPageSettle(page);
+
+  const critical = errors.filter(
+    e => (e.includes('TypeError') || e.includes('Cannot read')) &&
+         !e.includes('Failed to fetch') && !e.includes('Error loading recent')
+  );
+  expect(critical, `Forward-compat upgrade errors:\n${critical.join('\n')}`).toHaveLength(0);
+  await expect(page.getByText('Panel plugin not found', { exact: false })).not.toBeVisible();
+  console.log('✅ Phase2 — andGroup filter dashboard loads after upgrade');
+});
+
+test('phase2: provisioned dashboards all pass after upgrade', async ({
+  readProvisionedDashboard,
+  page,
+}) => {
+  for (const version of ['v0.2.2', 'v0.2.3', 'v0.3.0']) {
+    const dashboard = await readProvisionedDashboard({ fileName: `${version}.json` });
+    const errors: string[] = [];
+    page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+
+    await page.goto(`http://localhost:3000/d/${dashboard.uid}`);
+    await waitForPageSettle(page);
+
+    const critical = errors.filter(
+      e => (e.includes('TypeError') || e.includes('Cannot read')) &&
+           !e.includes('Failed to fetch') && !e.includes('Error loading recent')
+    );
+    expect(critical, `${version} post-upgrade errors:\n${critical.join('\n')}`).toHaveLength(0);
+    await expect(page.getByText('Panel plugin not found', { exact: false })).not.toBeVisible();
+    console.log(`✅ ${version} OK after upgrade`);
+  }
+});


### PR DESCRIPTION
## Summary

### Bug fixes
- **`types.ts`**: `GAFilter.numberFilter` → `numericFilter` (wrong JSON key — GA4 API never received the filter value)
- **`types.ts`**: `GANumbericFilterOperation` was a numeric TypeScript enum (`0, 1, 2…`) → fixed to string enum (`'EQUAL'`, `'LESS_THAN'`, …) so values serialise correctly to the GA4 API
- **`DataSource.ts`**: `metricFilter` was not being interpolated in `applyTemplateVariables` — `$variable` references in metric filters were sent unexpanded to the backend

### New features

#### Frontend
- **`Filter.tsx`** — complete rewrite of the filter component
  - All 5 GA4 filter types now supported: **String · InList · Numeric · Between · Empty**
  - `StringEditor`: match-type dropdown + value input + case-sensitive toggle (`Aa` label + `InlineSwitch`)
  - `InListEditor`: `TagsInput` (press Enter to add values; supports `$variable` template vars) + case toggle
  - `NumericEditor`: operation select (`=`, `<`, `≤`, `>`, `≥`) + number input
  - `BetweenEditor`: from/to number inputs with `–` separator
  - `LeafFilterEditor`: `AsyncSelect` with `allowCustomValue` for field names (allows `$variable` in field name)
  - Groups (AND/OR/NOT) show depth-coded coloured left borders via `useStyles2`
  - `numericValueStr` / `strToNumericValue` helpers handle int64 (JSON string) / double round-trip correctly
- **`QueryEditorGA4.tsx`**: added **Metric Filter** section
  - Tooltip: _"Filter rows by metric values — applied after aggregation (SQL HAVING equivalent)"_
  - Mode-aware: loads realtime vs standard metric fields depending on current query mode
  - Dimension Filter `loadFields` now loads all available dimension fields (not just the currently selected ones)

#### Backend
- **`pkg/model/models.go`**: added `MetricFilter analyticsdata.FilterExpression` field to `QueryModel`
- **`pkg/gav4/client.go`**: forward `MetricFilter` to both `RunReport` and `RunRealtimeReport` requests

### Tests added / strengthened

| File | New cases |
|------|-----------|
| `src/DataSource.test.ts` | metricFilter interpolation, immutability (deep-clone), undefined passthrough, simultaneous dim+metric filter expansion |
| `src/interpolation.test.ts` | NUMERIC filter (no-op), BETWEEN filter (no crash + values intact), EMPTY filter (no crash) |
| `pkg/model/models_test.go` | `TestQueryModel_FilterRoundTrip` — dim+metric filter JSON round-trip; `TestQueryModel_EmptyFilterIsOmitted` — `omitempty` keeps zero-value filters out of JSON so backend nil-checks work |

## Test plan
- [ ] `yarn typecheck` — 0 errors
- [ ] `yarn test:ci` — all tests pass (frontend)
- [ ] `mage coverage` — all tests pass (backend)
- [ ] Manual: open query editor, verify Dimension Filter and Metric Filter rows appear; test each filter type (String/InList/Numeric/Between/Empty); test AND/OR/NOT groups with coloured borders; test `$variable` in InList values
- [ ] Manual: verify realtime mode loads realtime fields in both filter dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메트릭 필터 UI 추가 — 차원 필터와 별도으로 메트릭 필터 생성·편집 가능.
  * 새 재귀식 필터 편집기 도입 — 비동기 필드 조회 및 다양한 리프 타입(문자열/목록/숫자/범위/빈값) 지원.

* **개선 사항**
  * 필터 전송 로직 개선 — 빈 필터는 전송되지 않도록 조건적 적용.
  * 템플릿 변수 적용 시 차원·메트릭 필터를 깊은 복사하여 원본 불변 보장.

* **테스트**
  * 단위 테스트 확장 및 새로운 Playwright E2E 테스트(필터 UI, 마이그레이션·업그레이드 시뮬레이션) 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackcowmoo/grafana-google-analytics-datasource/pull/169)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->