### PR TITLE
fix(release): pin go-version to 1.26.4 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,5 +22,7 @@ jobs:
         with:
         # Make sure to save the token in your repository secrets
           policy_token: ${{ secrets.GRAFANA_API_KEY }}
+          # go.mod requires go 1.26.4 (grafana-plugin-sdk-go v0.292.2); action defaults to 1.25
+          go-version: '1.26.4'
         # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above
         #grafana_token: $


### PR DESCRIPTION
## Summary
- `go.mod` requires `go >= 1.26.4` (pulled in by `github.com/grafana/grafana-plugin-sdk-go v0.292.2` in #172), but the `grafana/plugin-actions/build-plugin@build-plugin/v1.2.0` action defaults to Go 1.25 and pins `GOTOOLCHAIN=local`, so it can't auto-upgrade.
- This broke the release workflow: https://github.com/blackcowmoo/grafana-google-analytics-datasource/actions/runs/29100394034/job/86387459745
  ```
  go: go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
  Error parsing magefiles: error running "go list ... github.com/grafana/grafana-plugin-sdk-go/build": exit status 1
  ```
- Fix: explicitly pass `go-version: '1.26.4'` to the `build-plugin` action so `actions/setup-go` installs a toolchain that satisfies `go.mod`.

## Test plan
- [ ] Push a version tag (or re-run the release workflow) and confirm the `Run magefile/mage-action` step in the `release` job succeeds instead of failing at "Error parsing magefiles".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 릴리즈 빌드 환경에서 Go 버전을 1.26.4로 명시적으로 고정했습니다.
  * 프로젝트 요구 버전과 빌드 액션 기본값 간의 차이를 설명하는 주석을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->