### PR TITLE
Hide unimplemented GCE auth option from config editor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+node_modules
+dist
+coverage
+tests
+playwright-report
+test-results

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,8 +1,7 @@
-# Standalone debug image: attach a Go debugger to the plugin backend without
-# docker-compose. Build the plugin first, then build and run this image —
-# it bakes the plugin and provisioning in, so no -v mounts are needed:
+# Standalone debug image: builds the plugin from source and attaches a Go
+# debugger to the backend, all inside `docker build` — no host toolchain or
+# prebuilt ./dist required:
 #
-#   yarn build && mage
 #   docker build -f Dockerfile-debug -t ga-datasource-debug .
 #   docker run -p 3000:3000 -p 2345:2345 \
 #     --cap-add=SYS_PTRACE --security-opt apparmor=unconfined \
@@ -16,9 +15,10 @@ USER root
 WORKDIR /root
 
 ENV GOFLAGS=-buildvcs=false
+ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
 
 RUN apt-get -y update
-RUN apt-get -y install git build-essential
+RUN apt-get -y install git build-essential curl
 
 RUN curl -L https://golang.org/dl/go1.26.4.linux-amd64.tar.gz > go1.26.4.linux-amd64.tar.gz
 
@@ -27,17 +27,26 @@ RUN rm -rf /usr/local/go && \
 
 RUN touch README; printf "~~~~~~ START THE DLV SERVER WITH THIS COMMAND BEFORE RUNNING IDE DEBUGGER ~~~~~~ \r\ndlv attach --headless --listen=:2345 PID\r\n\r\n" >> README
 
-RUN echo "export PATH=$PATH:/usr/local/go/bin:~/go/bin" >> ~/.bashrc
+RUN echo "export PATH=$PATH" >> ~/.bashrc
 RUN echo "cat ~/README" >> ~/.bashrc
 
-RUN /usr/local/go/bin/go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN git clone https://github.com/magefile/mage; \
     cd mage; \
-    export PATH=$PATH:/usr/local/go/bin; \
     go run bootstrap.go
 
-# Bake the built plugin + provisioning in so the container runs it
-# automatically, matching docker-compose.yaml's volume mounts.
+# Node/Yarn to build the frontend from source (the backend build below uses
+# the Go/mage toolchain already installed above).
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g yarn@1.22.19
+
+# Build the plugin from source inside the image, then bake it + provisioning
+# in so the container runs it automatically — no -v mounts needed.
 ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=blackcowmoo-googleanalytics-datasource
-COPY dist /var/lib/grafana/plugins/blackcowmoo-googleanalytics-datasource
-COPY provisioning /etc/grafana/provisioning
+WORKDIR /root/plugin
+COPY . .
+RUN yarn install --frozen-lockfile && yarn build
+RUN mage build:linux
+RUN cp -r dist /var/lib/grafana/plugins/blackcowmoo-googleanalytics-datasource && \
+    cp -r provisioning /etc/grafana/provisioning

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -8,45 +8,48 @@
 #     ga-datasource-debug
 #
 # Then exec into the container, find the plugin backend's PID, and run the
-# dlv attach command printed in ~/README.
-FROM grafana/grafana:10.4.0-ubuntu
+# dlv attach command printed in ~/README. The Node/Go build toolchains only
+# live in the builder stages below — the final image just carries Grafana,
+# the built plugin, and the dlv binary needed to attach to it.
 
-USER root
-WORKDIR /root
+# ---- Frontend build stage: produces the static assets under ./dist ----
+FROM node:20 AS frontend-builder
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY tsconfig.json README.md LICENSE CHANGELOG.md ./
+COPY .config ./.config
+COPY src ./src
+RUN yarn build
 
+# ---- Backend build stage: produces the plugin binary + dlv under ./dist ----
+FROM golang:1.26.4 AS backend-builder
+WORKDIR /app
 ENV GOFLAGS=-buildvcs=false
-ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
-
-RUN apt-get -y update
-RUN apt-get -y install git build-essential curl
-
-RUN curl -L https://golang.org/dl/go1.26.4.linux-amd64.tar.gz > go1.26.4.linux-amd64.tar.gz
-
-RUN rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
-
-RUN touch README; printf "~~~~~~ START THE DLV SERVER WITH THIS COMMAND BEFORE RUNNING IDE DEBUGGER ~~~~~~ \r\ndlv attach --headless --listen=:2345 PID\r\n\r\n" >> README
-
-RUN echo "export PATH=$PATH" >> ~/.bashrc
-RUN echo "cat ~/README" >> ~/.bashrc
+COPY go.mod go.sum ./
+RUN go mod download
+COPY pkg ./pkg
+COPY Magefile.go ./
+COPY src/plugin.json ./src/plugin.json
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN git clone https://github.com/magefile/mage; \
     cd mage; \
     go run bootstrap.go
-
-# Node/Yarn to build the frontend from source (the backend build below uses
-# the Go/mage toolchain already installed above).
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g yarn@1.22.19
-
-# Build the plugin from source inside the image, then bake it + provisioning
-# in so the container runs it automatically — no -v mounts needed.
-ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=blackcowmoo-googleanalytics-datasource
-WORKDIR /root/plugin
-COPY . .
-RUN yarn install --frozen-lockfile && yarn build
 RUN mage build:linux
-RUN cp -r dist /var/lib/grafana/plugins/blackcowmoo-googleanalytics-datasource && \
-    cp -r provisioning /etc/grafana/provisioning
+
+# ---- Final image: Grafana + the built plugin + dlv, nothing else ----
+FROM grafana/grafana:10.4.0-ubuntu
+
+USER root
+
+RUN printf "~~~~~~ START THE DLV SERVER WITH THIS COMMAND BEFORE RUNNING IDE DEBUGGER ~~~~~~ \r\ndlv attach --headless --listen=:2345 PID\r\n\r\n" > /root/README && \
+    echo "cat ~/README" >> /root/.bashrc
+
+# Bake the built plugin + provisioning in so the container runs it
+# automatically — no -v mounts needed.
+ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=blackcowmoo-googleanalytics-datasource
+COPY --from=backend-builder /go/bin/dlv /usr/local/bin/dlv
+COPY --from=frontend-builder /app/dist /var/lib/grafana/plugins/blackcowmoo-googleanalytics-datasource
+COPY --from=backend-builder /app/dist /var/lib/grafana/plugins/blackcowmoo-googleanalytics-datasource
+COPY provisioning /etc/grafana/provisioning

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,3 +1,15 @@
+# Standalone debug image: attach a Go debugger to the plugin backend without
+# docker-compose. Build the plugin first, then build and run this image —
+# it bakes the plugin and provisioning in, so no -v mounts are needed:
+#
+#   yarn build && mage
+#   docker build -f Dockerfile-debug -t ga-datasource-debug .
+#   docker run -p 3000:3000 -p 2345:2345 \
+#     --cap-add=SYS_PTRACE --security-opt apparmor=unconfined \
+#     ga-datasource-debug
+#
+# Then exec into the container, find the plugin backend's PID, and run the
+# dlv attach command printed in ~/README.
 FROM grafana/grafana:10.4.0-ubuntu
 
 USER root
@@ -23,3 +35,9 @@ RUN git clone https://github.com/magefile/mage; \
     cd mage; \
     export PATH=$PATH:/usr/local/go/bin; \
     go run bootstrap.go
+
+# Bake the built plugin + provisioning in so the container runs it
+# automatically, matching docker-compose.yaml's volume mounts.
+ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=blackcowmoo-googleanalytics-datasource
+COPY dist /var/lib/grafana/plugins/blackcowmoo-googleanalytics-datasource
+COPY provisioning /etc/grafana/provisioning

--- a/pkg/gav4/client.go
+++ b/pkg/gav4/client.go
@@ -3,6 +3,7 @@ package gav4
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/blackcowmoo/grafana-google-analytics-dataSource/pkg/auth"
@@ -250,11 +251,21 @@ func (client *GoogleClient) getRealtimeReport(query model.QueryModel) (*analytic
 // 	log.DefaultLogger.Info("Completed printing response", "", "")
 // }
 
-func (client *GoogleClient) getMetadata(propertyID string) (*analyticsdata.Metadata, error) {
+// metadataResourceName builds the "properties/{id}/metadata" resource name
+// the Data API expects. propertyID may be passed either as a bare numeric ID
+// or as the full "properties/{id}" resource name (e.g. WebPropertyID as
+// stored from account summaries / the cascader) — TrimPrefix normalises
+// both so callers can't end up with a doubled "properties/properties/..." path.
+func metadataResourceName(propertyID string) string {
+	propertyID = strings.TrimPrefix(propertyID, "properties/")
 	if propertyID == "" {
 		propertyID = "0"
 	}
-	nameid := "properties/" + propertyID + "/metadata"
+	return "properties/" + propertyID + "/metadata"
+}
+
+func (client *GoogleClient) getMetadata(propertyID string) (*analyticsdata.Metadata, error) {
+	nameid := metadataResourceName(propertyID)
 	metadata, err := client.analyticsdata.Properties.GetMetadata(nameid).Do()
 	if err != nil {
 		return nil, err

--- a/pkg/gav4/client_test.go
+++ b/pkg/gav4/client_test.go
@@ -1,0 +1,26 @@
+package gav4
+
+import "testing"
+
+func TestMetadataResourceName(t *testing.T) {
+	cases := []struct {
+		name       string
+		propertyID string
+		want       string
+	}{
+		{"bare numeric id", "390931478", "properties/390931478/metadata"},
+		// WebPropertyID is stored as the full resource name everywhere else
+		// (account summaries, RunReport) — getMetadata must not double the
+		// "properties/" prefix when it's already present.
+		{"full resource name", "properties/390931478", "properties/390931478/metadata"},
+		{"empty falls back to 0", "", "properties/0/metadata"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := metadataResourceName(tc.propertyID); got != tc.want {
+				t.Errorf("metadataResourceName(%q) = %q, want %q", tc.propertyID, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -1,19 +1,26 @@
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { ConnectionConfig } from '@grafana/google-sdk';
+import { AuthConfig, GOOGLE_AUTH_TYPE_OPTIONS, GoogleAuthType } from '@grafana/google-sdk';
 import { Alert } from '@grafana/ui';
 import React from 'react';
 import { GADataSourceOptions, GASecureJsonData } from 'types';
 
 export type Props = DataSourcePluginOptionsEditorProps<GADataSourceOptions, GASecureJsonData>;
 
+// The backend (pkg/auth/auth.go) only implements JWT auth — GCE and Workload
+// Identity Federation are recognized but return a "not yet supported" error
+// on Save & test. <ConnectionConfig /> has no prop to hide individual auth
+// types, so we render its underlying <AuthConfig /> directly with just the
+// JWT option instead.
+const SUPPORTED_AUTH_OPTIONS = GOOGLE_AUTH_TYPE_OPTIONS.filter((option) => option.value === GoogleAuthType.JWT);
+
 export const ConfigEditor: React.FC<Props> = (props) => {
-  const { options } = props;
+  const { options, onOptionsChange } = props;
 
   // Backwards compat: a datasource created before @grafana/google-sdk
   // adoption stores the full service-account JSON in `secureJsonData.jwt`.
   // The backend's auth.Resolve still parses that blob, so existing
   // datasources keep authenticating without any user action. New
-  // datasources go through <ConnectionConfig /> below and persist the
+  // datasources go through <AuthConfig /> below and persist the
   // explicit (clientEmail / tokenUri / privateKey) fields the SDK reads.
   const usingLegacyJWT =
     options.secureJsonFields?.jwt &&
@@ -25,13 +32,13 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       {usingLegacyJWT && (
         <Alert title="Legacy JWT credentials detected" severity="info">
           This datasource was set up before the unified Google authentication
-          UI. Existing queries continue to work, but to take advantage of new
-          auth options (GCE / Workload Identity / Service Account
-          Impersonation) re-upload your service-account JSON below.
+          UI. Existing queries continue to work, but to take advantage of the
+          unified JWT upload/paste flow, re-upload your service-account JSON
+          below.
         </Alert>
       )}
 
-      <ConnectionConfig {...props} />
+      <AuthConfig authOptions={SUPPORTED_AUTH_OPTIONS} options={options} onOptionsChange={onOptionsChange} />
 
       <Alert title="Generate a JWT file" severity="info">
         <ol style={{ listStylePosition: 'inside' }}>

--- a/tests/config/configEditor.spec.ts
+++ b/tests/config/configEditor.spec.ts
@@ -71,6 +71,24 @@ test('"Save & test" should fail when configuration is invalid', async ({
   await expect(configPage).toHaveAlert('error');
 });
 
+// GCE and Workload Identity Federation are recognized by @grafana/google-sdk
+// but pkg/auth/auth.go returns a "not yet supported" error for both, so
+// ConfigEditor.tsx renders <AuthConfig /> with a JWT-only authOptions list
+// instead of the SDK's default <ConnectionConfig />. This asserts the GCE
+// radio option stays hidden so users can't pick an auth type that always
+// fails Save & test.
+test('auth type selector only offers JWT (GCE is not implemented on the backend)', async ({
+  gotoDataSourceConfigPage,
+  readProvisionedDataSource,
+  page,
+}) => {
+  const ds = await readProvisionedDataSource<GADataSourceOptions, GASecureJsonData>({ fileName: 'datasources.yml' });
+  await gotoDataSourceConfigPage(ds.uid);
+  await dismissWhatsNewModal(page);
+  await expect(page.getByText('Google JWT File')).toBeVisible();
+  await expect(page.getByText('GCE Default Service Account')).toHaveCount(0);
+});
+
 // Backwards compatibility: a datasource saved before gav3 was removed will
 // still have `jsonData.version = "v3"` persisted. The plugin must load that
 // config without crashing — the value is ignored and the GA4 path is used.


### PR DESCRIPTION
## Summary
- Selecting "GCE Default Service Account" in the datasource config and clicking Save & test always failed with `auth: "gce" is not yet supported"`, since `pkg/auth/auth.go` only implements JWT auth (GCE/WIF constants exist but their `Resolve`/token-provider paths were never built out).
- `@grafana/google-sdk`'s `<ConnectionConfig />` hardcodes both JWT and GCE as selectable auth options with no prop to exclude one, so the fix renders its underlying `<AuthConfig />` component directly with a JWT-only `authOptions` list — this removes the GCE radio button entirely instead of letting users pick an option that always fails.
- Backend `pkg/auth/auth.go` is left untouched as a safety net for any pre-existing/API-set datasource configs with `authenticationType: gce`.

## Affected scope
- `src/ConfigEditor.tsx` only — no backend changes. Workload Identity Federation was already hidden before this change (the SDK only adds it when an `enableWIF` prop is passed, which this datasource never did).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on both changed files
- [ ] `yarn e2e` (requires a live Grafana via `docker compose up`) — added a new Playwright test in `tests/config/configEditor.spec.ts` asserting the config page shows "Google JWT File" but not "GCE Default Service Account"; please run the suite to confirm it passes against a real Grafana instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * Config 편집기에서 Google JWT 인증을 통합 JWT 흐름 UI로 전환하고, 선택기에는 지원되는 옵션만 표시되도록 조정했습니다.
  * 기존 인증 형식 감지 시 안내 문구를 새 업로드/붙여넣기 방식에 맞게 업데이트했습니다.
  * GA4 메타데이터 리소스 이름 생성 시 입력 형식을 정규화해 잘못된 경로 중복을 방지했습니다.
* **테스트**
  * ConfigEditor에서 “Google JWT File”은 표시되고 “GCE 기본 서비스 계정”은 숨겨지는 케이스를 추가했습니다.
* **문서/배포**
  * 디버그 Dockerfile 빌드/실행 안내를 보강하고, Docker 빌드 컨텍스트 용량을 줄이도록 .dockerignore를 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->