### PR TITLE
docs(changelog): add 0.3.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.2
+- Remove deprecated GA3 (Universal Analytics) datasource — GA4 only going forward([#165](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/165))
+- Complete GA4 filter UI overhaul with MetricFilter support([#169](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/169))
+- Support accounts/properties as dashboard variables([#167](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/167))
+- Add dashboard variable support for webPropertyId([#152](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/152))
+- Fix expanding multi-value variables in filter expressions([#154](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/154))
+- Fix sub-day Grafana time range not respected in time-series output([#156](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/156))
+- Fix rows with unparseable time dimension causing failures([#155](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/155))
+
 ## 0.3.1
 - Support or,and,not filter[#128](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/128)
 - Support grafana version < 13[#136](https://github.com/blackcowmoo/grafana-google-analytics-datasource/pull/136)


### PR DESCRIPTION
## Summary
- Adds a `## 0.3.2` section to `CHANGELOG.md` covering functional changes merged since the `v0.3.1` tag
- Focuses on user-facing feature additions and bug fixes; internal refactors, dependency bumps, and CI/test-only changes were intentionally left out to keep the log meaningful
- Calls out the GA3 (Universal Analytics) datasource removal explicitly since it's a breaking change

## Affected scope
- `CHANGELOG.md` only — no code changes

## Test plan
- [x] Docs-only change; reviewed formatting/ordering against existing changelog entries for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * GA4 필터 UI와 MetricFilter 지원이 추가되었습니다.
  * 대시보드 변수를 통한 계정·속성 및 webPropertyId 설정을 지원합니다.
  * 다중 값 변수와 필터 표현식 기능이 확장되었습니다.

* **버그 수정**
  * Grafana의 서브데이 시간 범위가 올바르게 반영됩니다.
  * 시간 차원 파싱 실패로 인한 오류가 수정되었습니다.
  * GA3(Universal Analytics) 데이터소스가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->