### PR TITLE
fix(docker): update debug image to Grafana 10.4.0 and Go 1.26.4

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,17 +1,17 @@
-FROM grafana/grafana:9.5.2-ubuntu
+FROM grafana/grafana:10.4.0-ubuntu
 
 USER root
 WORKDIR /root
 
-ENV GOFLAGS -buildvcs=false
+ENV GOFLAGS=-buildvcs=false
 
 RUN apt-get -y update
 RUN apt-get -y install git build-essential
 
-RUN curl -L https://golang.org/dl/go1.18.linux-amd64.tar.gz > go1.18.linux-amd64.tar.gz
+RUN curl -L https://golang.org/dl/go1.26.4.linux-amd64.tar.gz > go1.26.4.linux-amd64.tar.gz
 
 RUN rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 RUN touch README; printf "~~~~~~ START THE DLV SERVER WITH THIS COMMAND BEFORE RUNNING IDE DEBUGGER ~~~~~~ \r\ndlv attach --headless --listen=:2345 PID\r\n\r\n" >> README
 


### PR DESCRIPTION
## Summary
- `Dockerfile-debug` still pinned `grafana/grafana:9.5.2-ubuntu` and Go `1.18`, both far behind what this repo now targets (the dev `docker-compose.yaml` defaults to Grafana `10.4.0`, and `go.mod` requires Go `1.26.4`), so the image no longer reflected a runnable debug environment.
- Bumped the base image to `grafana/grafana:10.4.0-ubuntu` and the Go download/install to `1.26.4` to match the rest of the toolchain.
- Also fixed the legacy `ENV key value` syntax (`GOFLAGS`) that Docker now flags as deprecated, switching it to `ENV key=value`.

## Affected scope
- Only `Dockerfile-debug`, the standalone image used for manual delve-based backend debugging (build + `docker exec` in, per the in-image README instructions). Does not touch `docker-compose.yaml` or `.config/Dockerfile`, which are used for the normal dev/e2e workflow.

## Test plan
- [x] `docker build -f Dockerfile-debug -t ga4-debug-test .` completes successfully with no errors or deprecation warnings.
- [x] Ran the built image and verified via `docker exec`: `go version` reports `go1.26.4`, and both `dlv` (v1.27.0) and `mage` are installed under `/root/go/bin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **업데이트**
  * 디버그 환경의 Grafana 버전을 10.4.0으로 업데이트했습니다.
  * Go 버전을 1.26.4로 업그레이드해 최신 개발 환경을 제공합니다.
  * Go 빌드 설정을 조정해 빌드 시 불필요한 버전 관리 정보를 제외합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->